### PR TITLE
Optical inspection relational model

### DIFF
--- a/dbExamples/cbm_sts/macros/sensor_test.C
+++ b/dbExamples/cbm_sts/macros/sensor_test.C
@@ -1,0 +1,440 @@
+bool table_exists(string table_name)
+{
+  Int_t db_entry = 0;
+  TString name(table_name);
+  name.ToUpper();
+  FairDbConnectionPool* connectionPool = FairDbTableInterfaceStore::Instance().fConnectionPool;
+  return connectionPool->TableExists(name.Data(), db_entry);
+}
+
+void create_db_tables()
+{
+  StsDefect defect; defect.CreateDbTable(0);
+  StsDefectContext defectContext; defectContext.CreateDbTable(0);
+  StsDefectType defectType; defectType.CreateDbTable(0);
+  StsInspectionImage image; image.CreateDbTable(0);
+  StsOpticalInspection inspection; inspection.CreateDbTable(0);
+  StsSensor sensor; sensor.CreateDbTable(0);
+  StsSensorBatch batch; batch.CreateDbTable(0);
+  StsSensorLocation location; location.CreateDbTable(0);
+  StsSensorType type; type.CreateDbTable(0);
+  StsSensorVendor vendor; vendor.CreateDbTable(0);
+}
+
+void prime_defect_context()
+{
+  string logTitle = "Defect Context Priming";
+  
+  struct defect_context_t {
+    Int_t    fId;
+    char*    fContextName;
+    Double_t fWeight;
+  };
+
+  defect_context_t defectContexts[] = {
+    {0, "Strips",          0.5},
+    {1, "AC Pads",         0.1},
+    {2, "DC Pads",         1.},
+    {3, "Bias Resistors",  1.},
+    {4, "Guard Ring",      1.},
+    {5, "Non-active zone", 0.05},
+    {6, "Other",           0.05 }
+  };
+
+  StsDefectContext defectContext;
+  for (int i=0; i<7; i++ ) {
+    defectContext.SetLogTitle(logTitle);
+    defectContext.SetCompId(i);
+    defectContext.SetId(i);
+    defectContext.SetContextName(defectContexts[i].fContextName);
+    defectContext.SetWeight(defectContexts[i].fWeight);
+    
+    defectContext.store();
+  }
+}
+
+void prime_defect_type()
+{
+  string logTitle = "Defect Type Priming";
+  
+  struct defect_type_t {
+    Int_t    fId;
+    char*    fTypeName;
+    Double_t fWeight;
+  };
+
+  defect_type_t defectTypes[] = {
+    {0, "Scratch",       0.5},
+    {1, "Dust",          0.1},
+    {2, "Metal Short",   1.},
+    {3, "Metal Break",   1.},
+    {4, "Implant open",  1.},
+    {5, "Other",         0.05 }
+  };
+
+  StsDefectType defectType;
+  for (int i=0; i<6; i++ ) {
+    defectType.SetLogTitle(logTitle);
+    defectType.SetCompId(i);
+    defectType.SetId(i);
+    defectType.SetTypeName(defectTypes[i].fTypeName);
+    defectType.SetWeight(defectTypes[i].fWeight);
+
+    defectType.store();
+  }
+}
+
+void prime_defect()
+{
+  string logTitle = "Defect Priming";
+
+  ValTimeStamp start = ValTimeStamp::GetBOT();
+  ValTimeStamp end = ValTimeStamp::GetEOT();
+  ValInterval context(FairDbDetector::kSts,DataType::kData,start, end, logTitle);
+
+  StsDefect defect;
+  FairDbWriter<StsDefect> w_defect;
+  w_defect.Activate(context, 0, defect.GetVersion(), defect.GetDbEntry(), logTitle);
+  for (int i=0; i<10; i++ ) {
+    defect.SetLogTitle(logTitle);
+    defect.SetCompId(0);
+    defect.SetId(i);
+
+    w_defect << defect;
+  }
+
+  w_defect.Close();
+}
+
+void prime_sensor_vendor()
+{
+  string logTitle = "Vendor Priming";
+  
+  struct vendor_type_t {
+    Int_t    fId;
+    char*    fVendorName;
+    char*    fLocation;
+    char*    fContactInfo;
+    char*    fComment;
+  };
+
+  vendor_type_t vendors[] = {
+    {0, "Hamamatsu",     "325-6, Sunayama-cho, Naka-ku, Hamamatsu City, Shizuoka Pref., 430-8587, Japan", "Phone:(81)53-452-2141 Fax:(81)53-456-7889",                 "They make good sensors"},
+    {1, "CIS",           "CiS electronic GmbH, Europark Fichtenhain A15, D – 47807 Krefeld",              "Tel.: +49 21 51 / 37 87 – 0 Fax.: +49 21 51 / 37 87 – 11",  "They make good sensors"},
+  };
+
+  StsSensorVendor vendor;
+  for (int i=0; i<2; i++ ) {
+    vendor.SetLogTitle(logTitle);
+    vendor.SetCompId(i);
+    vendor.SetId(i);
+    vendor.SetVendorName(vendors[i].fVendorName);
+    vendor.SetLocation(vendors[i].fLocation);
+    vendor.SetContactInfo(vendors[i].fContactInfo);
+    vendor.SetComment(vendors[i].fComment);
+
+    vendor.store();
+  }
+}
+
+void prime_sensor_type()
+{
+  string logTitle = "Defect Type Priming";
+ 
+  struct sensor_type_t {
+    Int_t    fId;
+    char*    fTypeName;
+    char*    fProcessing;
+    Double_t fWidth;
+    Double_t fHeight;
+    Double_t fAliMarkWidth;
+    Double_t fAliMarkHeight;
+    Int_t    fStripsPerSide;
+    Double_t fPitch;
+    Double_t fThickness;
+    Double_t fStereoAngleP;
+    Double_t fStereoAngleN;
+    char*    fComment;
+  };
+
+  sensor_type_t types[] = {
+    {0 , "CBM06C12",     "DSDM", 62000.,  124000., 121400.,  61400.,    1024, 58.,   280., 7.5, 0.,   ""},
+    {1 , "CBM06C6",      "DSDM", 62000.,  62000.,  61400.,   61400.,    1024, 58.,   280., 7.5, 0.,   ""},
+    {2 , "CBM06C4",      "DSDM", 62000.,  42000.,  41400.,   61400.,    1024, 58.,   280., 7.5, 0.,   ""},
+    {3 , "CBM06C2",      "DSDM", 62000.,  22000.,  21400.,   61400.,    1024, 58.,   280., 7.5, 0.,   ""},
+    {4 , "CBM06H12",     "DSDM", 62000.,  124000., 121400.,  61400.,    1024, 58.,   320., 7.5, 0.,   ""},
+    {5 , "CBM06H6",      "DSDM", 62000.,  62000.,  61400.,   61400.,    1024, 58.,   320., 7.5, 0.,   ""},
+    {6 , "CBM06H4",      "DSDM", 62000.,  42000.,  41400.,   61400.,    1024, 58.,   320., 7.5, 0.,   ""},
+    {7 , "CBM06H2",      "DSDM", 62000.,  22000.,  21400.,   61400.,    1024, 58.,   320., 7.5, 0.,   ""},
+    {8 , "CBM05C1",      "DSSM", 11925.,  11925.,  11175.,   11175.,    192,  50.,   0.,   90., 0.,   "Baby Sensor, Look up thickness"},
+    {9 , "CBM03C6",      "DSDM", 62000.,  62000.,  61361.2,  60756.08,  1024, 60.,   0.,   7.5, 7.5,  "Look up thickness"},
+    {10, "CBM01",        "DSDM", 54899.2, 53854.5, 54899.2,  53854.5,   1024, 50.7,  0.,   7.5, 7.5,  "Look up thickness"},
+    {11, "CBM01B1",      "DSSM", 22359.,  22425.,  22359.,   22425.,    256,  80.,   0.,   90., 0.,   "Look up thickness"},
+    {12, "CBM01B2",      "DSSM", 14865.5, 14916.5, 14865.5,  14916.5,   256,  50.7,  0.,   90., 0.,   "Look up thickness"}
+  };
+
+  StsSensorType sensorType;
+  for (int i=0; i<13; i++ ) {
+    sensorType.SetLogTitle(logTitle);
+    sensorType.SetCompId(i);
+    sensorType.SetId(types[i].fId);
+    sensorType.SetTypeName(types[i].fTypeName);
+    sensorType.SetProcessing(types[i].fProcessing);
+    sensorType.SetWidth(types[i].fWidth);
+    sensorType.SetHeight(types[i].fHeight);
+    sensorType.SetAliMarkWidth(types[i].fAliMarkWidth);
+    sensorType.SetAliMarkHeight(types[i].fAliMarkHeight);
+    sensorType.SetStripsPerSide(types[i].fStripsPerSide);
+    sensorType.SetPitch(types[i].fPitch);
+    sensorType.SetThickness(types[i].fThickness);
+    sensorType.SetStereoAngleP(types[i].fStereoAngleP);
+    sensorType.SetStereoAngleN(types[i].fStereoAngleN);
+    sensorType.SetComment(types[i].fComment);
+
+    sensorType.store();
+  }
+}
+
+void prime_sensor_location()
+{
+  string logTitle = "Sensor Location Priming";
+ 
+  struct sensor_location_t {
+    Int_t    fId;
+    char*    fLocation;
+    char*    fOwner;
+    char*    fComment;
+  };
+
+  sensor_location_t sensorLocations[] = {
+    {0, "GSI",           "J. Heuser",    "On Assembly"},
+    {1, "EKU Tuebingen", "H.R. Schmidt", "On Optical Inspection"},
+    {2, "JINR",          "Y. Murin",     "On Assembly"},
+  };
+
+  StsSensorLocation sensorLocation;
+  for (int i=0; i<3; i++ ) {
+    sensorLocation.SetLogTitle(logTitle);
+    sensorLocation.SetCompId(i);
+    sensorLocation.SetId(i);
+    sensorLocation.SetLocation(sensorLocations[i].fLocation);
+    sensorLocation.SetOwner(sensorLocations[i].fOwner);
+    sensorLocation.SetComment(sensorLocations[i].fComment);
+
+    sensorLocation.store();
+  }
+}
+
+void prime_sensor_batch()
+{
+  string logTitle = "Sensor Batch Priming";
+ 
+  struct sensor_batch_t {
+    Int_t           fId;
+    char*           fNumber;
+    ValTimeStamp    fDate;
+    char*           fComment;
+  };
+
+  sensor_batch_t sensorBatches[] = {
+    {0, "331140",           ValTimeStamp::GetBOT(),    "Very good batch"},
+    {1, "351135",           ValTimeStamp::GetBOT(),    "Very good batch"},
+    {2, "351139",           ValTimeStamp::GetBOT(),    "Very good batch"},
+    {3, "351141",           ValTimeStamp::GetBOT(),    "Very good batch"},
+    {4, "351142",           ValTimeStamp::GetBOT(),    "Very good batch"},
+    {5, "351152",           ValTimeStamp::GetBOT(),    "Very good batch"},
+  };
+
+  StsSensorBatch sensorBatch;
+  for (int i=0; i<6; i++ ) {
+    sensorBatch.SetLogTitle(logTitle);    sensorBatch.SetCompId(i);
+    sensorBatch.SetCompId(i);
+    sensorBatch.SetId(i);
+    sensorBatch.SetNumber(sensorBatches[i].fNumber);
+    sensorBatch.SetDate(sensorBatches[i].fDate);
+    sensorBatch.SetComment(sensorBatches[i].fComment);
+
+    sensorBatch.store();
+  }
+}
+
+void print_sensor(StsSensor *sensor)
+{
+  if (!sensor)
+    return;
+
+  sensor->Print();
+  TObjArray *inspections = sensor->GetOpticalInspections();
+  if (inspections)
+  {
+    cout << "Listing sensor inspections:" << endl;
+    for (Int_t i=0; i<inspections->GetEntriesFast(); i++)
+    {
+      cout << i << ":" << endl;
+      ((StsOpticalInspection *)inspections->At(i))->Print();
+    }
+  }
+  cout << endl;
+}
+
+void prime_sensor()
+{
+  string logTitle = "Sensor Priming";
+
+  StsSensor sensor;
+  for (int i=0; i<2; i++ ) {
+    sensor.SetLogTitle(logTitle);
+    sensor.SetCompId(i);
+    sensor.SetId(i);
+    sensor.SetReticleName("Main");
+    sensor.SetWaferNumber(1);
+    sensor.SetDate(ValTimeStamp::GetBOT());
+    sensor.SetQuality(1.);
+    sensor.SetQualityGrade("A++");
+    sensor.SetComment("Good Sensor");
+
+    sensor.store();
+  }
+}
+
+void sensor_read(Int_t sensorId = 0, UInt_t runId = 0)
+{
+  StsSensor* sensor = StsSensor::GetSensorById(sensorId, runId);
+  print_sensor(sensor);
+}
+
+void prime_optical_inspection()
+{
+  string logTitle = "Optical Inspection Priming";
+
+  ValTimeStamp start = ValTimeStamp::GetBOT();
+  ValTimeStamp end = ValTimeStamp::GetEOT();
+  ValInterval context(FairDbDetector::kSts,DataType::kData,start, end, logTitle);
+
+  StsOpticalInspection inspection;
+  FairDbWriter<StsOpticalInspection> w_inspection;
+  w_inspection.Activate(context, 0, inspection.GetVersion(), inspection.GetDbEntry(), logTitle);
+  for (int i=0; i<2; i++ ) {
+    inspection.SetLogTitle(logTitle);
+    inspection.SetCompId(0);
+    inspection.SetId(i);
+    inspection.SetSensorId(0);
+    inspection.SetSizeX(30);
+    inspection.SetSizeY(20);
+    inspection.SetDate(ValTimeStamp::GetBOT());
+    inspection.SetSensorSide("n");
+    inspection.SetMaxWarp(50.);
+    inspection.SetWarp(new TGraph2D());
+    inspection.SetThickness(280.);
+    inspection.SetQuality(1.);
+    inspection.SetQualityGrade("A++");
+    inspection.SetPassed(kTRUE);
+    inspection.SetComment("No comments");
+
+    w_inspection << inspection;
+  }
+
+  w_inspection.Close();
+}
+
+void prime_inspection_image()
+{
+  string logTitle = "Inspection Image Priming";
+
+  ValTimeStamp start = ValTimeStamp::GetBOT();
+  ValTimeStamp end = ValTimeStamp::GetEOT();
+  ValInterval context(FairDbDetector::kSts,DataType::kData,start, end, logTitle);
+
+  StsInspectionImage image;
+  FairDbWriter<StsInspectionImage> w_image;
+  w_image.Activate(context, 0, image.GetVersion(), image.GetDbEntry(), logTitle);
+  for (int i=0; i<5; i++ ) {
+    image.SetLogTitle(logTitle);
+    image.SetCompId(0);
+    image.SetId(i);
+    image.SetX(i);
+    image.SetY(i);
+    image.SetImageURI("smb://pipc40/Inspection Results/CBM06C6_331827-3/n_side/00_00.png");
+    image.SetThumbnailURI("smb://pipc40/Inspection Results/CBM06C6_331827-3/n_side/thumbnails/00_00.png");
+    image.SetOverlayURI("smb://pipc40/Inspection Results/CBM06C6_331827-3/n_side/results/00_00.png");
+
+    w_image << image;
+  }
+
+  w_image.Close();
+}
+
+void inspection_read(int id = 0, UInt_t runId = 0)
+{
+  StsOpticalInspection* inspection = StsOpticalInspection::GetInspectionById(id, runId);
+  if (!inspection)
+    return;
+  inspection->Print();
+
+  StsSensor* sensor = inspection->GetSensor();
+  if (!sensor)
+    return;
+
+  cout << "Sensor of this inspection: " << endl;
+  sensor->Print();
+}
+
+void test_relations()
+{
+  StsSensorBatch *batch = StsSensorBatch::GetBatchById(0);
+  batch->Print();
+  StsSensor *sensor = batch->GetSensors()->At(0);
+  sensor->Print();
+  StsSensorLocation *location = sensor->GetLocation();
+  location->Print();
+  StsSensorType *type = sensor->GetType();
+  type->Print();
+  StsSensorVendor *vendor = sensor->GetVendor();
+  vendor->Print();
+  StsOpticalInspection *inspection = sensor->GetOpticalInspections()->At(0);
+  inspection->Print();
+  StsInspectionImage *image = inspection->GetInspectionImages()->At(0);
+  image->Print();
+  StsDefect *defect = image->GetDefects()->At(0);
+  defect->Print();
+  StsDefectType *defectType = defect->GetType();
+  defectType->Print();
+  StsDefectContext *defectContext = defect->GetContext();
+  defectContext->Print();
+}
+
+void test_backward_relations()
+{
+  StsDefect *defect = StsDefect::GetDefectById(0);
+  defect->Print();
+  StsInspectionImage *image = defect->GetImage();
+  image->Print();
+  StsOpticalInspection *inspection = defect->GetInspection();
+  inspection->Print();
+  StsSensor *sensor = inspection->GetSensor();
+  sensor->Print();
+  StsSensorBatch *batch = sensor->GetBatch();
+  batch->Print();
+}
+
+void sensor_test()
+{
+  FairParTSQLIo *sql_io = new FairParTSQLIo();
+  sql_io->open();
+  sql_io->SetVerbosity(1);
+
+  create_db_tables();
+  prime_defect_context();
+  prime_defect_type();
+  prime_defect();
+  prime_sensor_vendor();
+  prime_sensor_type();
+  prime_sensor_location();
+  prime_sensor_batch();
+  prime_sensor();
+  prime_optical_inspection();
+  prime_inspection_image();
+
+  test_relations();
+  test_backward_relations();
+}

--- a/dbExamples/cbm_sts/src/CMakeLists.txt
+++ b/dbExamples/cbm_sts/src/CMakeLists.txt
@@ -40,6 +40,16 @@ CbmStsDbQa.cxx
 CbmStsDbQaSUID.cxx
 CbmStsDbQaSensor.cxx
 CbmStsDbQaIv.cxx
+StsSensorBatch.cxx
+StsDefect.cxx
+StsDefectContext.cxx
+StsDefectType.cxx
+StsInspectionImage.cxx
+StsOpticalInspection.cxx
+StsSensor.cxx
+StsSensorLocation.cxx
+StsSensorType.cxx
+StsSensorVendor.cxx
 )
 
 set(HEADERS
@@ -60,6 +70,16 @@ CbmStsDbQa.h
 CbmStsDbQaSUID.h
 CbmStsDbQaSensor.h
 CbmStsDbQaIv.h
+StsSensorBatch.h
+StsDefect.h
+StsDefectContext.h
+StsDefectType.h
+StsInspectionImage.h
+StsOpticalInspection.h
+StsSensor.h
+StsSensorLocation.h
+StsSensorType.h
+StsSensorVendor.h
 ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbReader.h
 ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbWriter.h
 )

--- a/dbExamples/cbm_sts/src/CbmStsDbQaLinkDef.h
+++ b/dbExamples/cbm_sts/src/CbmStsDbQaLinkDef.h
@@ -54,4 +54,55 @@
 #pragma link C++ class  CbmStsDbQaSensor+;
 #pragma link C++ class  CbmStsDbQaIv+;
 
+//-----------
+#pragma link C++ class FairDbReader<StsSensorBatch>+;
+#pragma link C++ class FairDbWriter<StsSensorBatch>+;
+#pragma link C++ class FairDbGenericParSet<StsSensorBatch>+;
+#pragma link C++ class StsSensorBatch+;
+
+#pragma link C++ class FairDbReader<StsDefect>+;
+#pragma link C++ class FairDbWriter<StsDefect>+;
+#pragma link C++ class FairDbGenericParSet<StsDefect>+;
+#pragma link C++ class StsDefect+;
+
+#pragma link C++ class FairDbReader<StsDefectContext>+;
+#pragma link C++ class FairDbWriter<StsDefectContext>+;
+#pragma link C++ class FairDbGenericParSet<StsDefectContext>+;
+#pragma link C++ class StsDefectContext+;
+
+#pragma link C++ class FairDbReader<StsDefectType>+;
+#pragma link C++ class FairDbWriter<StsDefectType>+;
+#pragma link C++ class FairDbGenericParSet<StsDefectType>+;
+#pragma link C++ class StsDefectType+;
+
+#pragma link C++ class FairDbReader<StsInspectionImage>+;
+#pragma link C++ class FairDbWriter<StsInspectionImage>+;
+#pragma link C++ class FairDbGenericParSet<StsInspectionImage>+;
+#pragma link C++ class StsInspectionImage+;
+
+#pragma link C++ class FairDbReader<StsOpticalInspection>+;
+#pragma link C++ class FairDbWriter<StsOpticalInspection>+;
+#pragma link C++ class FairDbGenericParSet<StsOpticalInspection>+;
+#pragma link C++ class StsOpticalInspection+;
+
+#pragma link C++ class FairDbReader<StsSensor>+;
+#pragma link C++ class FairDbWriter<StsSensor>+;
+#pragma link C++ class FairDbGenericParSet<StsSensor>+;
+#pragma link C++ class StsSensor+;
+
+#pragma link C++ class FairDbReader<StsSensorLocation>+;
+#pragma link C++ class FairDbWriter<StsSensorLocation>+;
+#pragma link C++ class FairDbGenericParSet<StsSensorLocation>+;
+#pragma link C++ class StsSensorLocation+;
+
+#pragma link C++ class FairDbReader<StsSensorType>+;
+#pragma link C++ class FairDbWriter<StsSensorType>+;
+#pragma link C++ class FairDbGenericParSet<StsSensorType>+;
+#pragma link C++ class StsSensorType+;
+
+#pragma link C++ class FairDbReader<StsSensorVendor>+;
+#pragma link C++ class FairDbWriter<StsSensorVendor>+;
+#pragma link C++ class FairDbGenericParSet<StsSensorVendor>+;
+#pragma link C++ class StsSensorVendor+;
+
 #endif

--- a/dbExamples/cbm_sts/src/StsDefect.cxx
+++ b/dbExamples/cbm_sts/src/StsDefect.cxx
@@ -1,0 +1,411 @@
+#include "StsDefect.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsDefect);
+
+static FairDbGenericParRegistry<StsDefect> sts("StsDefect", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsDefect>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsDefect>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsDefect>;
+
+StsDefect::StsDefect(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsDefect>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fInspectionId(0),
+  fTypeId(0),
+  fContextId(0),
+  fAlgorithmId(0),
+  fImageId(0),
+  fLeft(0.),
+  fTop(0.),
+  fWidth(0.),
+  fHeight(0.),
+  fCenterMassX(0.),
+  fCenterMassY(0.),
+  fArea(0.),
+  fPerimeter(0.),
+  fHydraulicRadius(0.),
+  fAreaRatio(0.),
+  fElongation(0.),
+  fCompactness(0.),
+  fCircularity(0.),
+  fComment("")
+{
+  fInspection = NULL;
+  fType = NULL;
+  fContext = NULL;
+  fImage = NULL;
+}
+
+StsDefect::~StsDefect()
+{
+  delete fInspection;
+  delete fType;
+  delete fContext;
+  delete fImage;
+}
+
+void StsDefect::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsDefect::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id",                        fId);
+  list->add("inspection_id",             fInspectionId);
+  list->add("type_id",                   fTypeId);
+  list->add("context_id",                fContextId);
+  list->add("algorithm_id",              fAlgorithmId);
+  list->add("image_id",                  fImageId);
+  list->add("left",                      fLeft);
+  list->add("top",                       fTop);
+  list->add("width",                     fWidth);
+  list->add("height",                    fHeight);
+  list->add("centermass_x",              fCenterMassX);
+  list->add("centermass_y",              fCenterMassY);
+  list->add("area",                      fArea);
+  list->add("perimeter",                 fPerimeter);
+  list->add("hydraulic_radius",          fHydraulicRadius);
+  list->add("area_ratio",                fAreaRatio);
+  list->add("elongation",                fElongation);
+  list->add("compactness",               fCompactness);
+  list->add("circularity",               fCircularity);
+  list->add("comment",         (Text_t*)&fComment);
+}
+
+Bool_t StsDefect::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id",                  &fId))                 { return kFALSE; }
+  if (!list->fill("inspection_id",       &fInspectionId))       { return kFALSE; }
+  if (!list->fill("type_id",             &fTypeId))             { return kFALSE; }
+  if (!list->fill("context_id",          &fContextId))          { return kFALSE; }
+  if (!list->fill("algorithm_id",        &fAlgorithmId))        { return kFALSE; }
+  if (!list->fill("image_id",            &fImageId))            { return kFALSE; }
+  if (!list->fill("left",                &fLeft))               { return kFALSE; }
+  if (!list->fill("top",                 &fTop))                { return kFALSE; }
+  if (!list->fill("width",               &fWidth))              { return kFALSE; }
+  if (!list->fill("height",              &fHeight))             { return kFALSE; }
+  if (!list->fill("centermass_x",        &fCenterMassX))        { return kFALSE; }
+  if (!list->fill("centermass_y",        &fCenterMassY))        { return kFALSE; }
+  if (!list->fill("area",                &fArea))               { return kFALSE; }
+  if (!list->fill("perimeter",           &fPerimeter))          { return kFALSE; }
+  if (!list->fill("hydraulic_radius",    &fHydraulicRadius))    { return kFALSE; }
+  if (!list->fill("area_ratio",          &fAreaRatio))          { return kFALSE; }
+  if (!list->fill("elongation",          &fElongation))         { return kFALSE; }
+  if (!list->fill("compactness",         &fCompactness))        { return kFALSE; }
+  if (!list->fill("circularity",         &fCircularity))        { return kFALSE; }
+
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))  {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsDefect::clear()
+{
+  fId = 0;
+  fInspectionId = 0;
+  fTypeId = 0;
+  fContextId = 0;
+  fAlgorithmId = 0;
+  fImageId = 0;
+  fLeft = 0.;
+  fTop = 0.;
+  fWidth = 0.;
+  fHeight = 0.;
+  fCenterMassX = 0.;
+  fCenterMassY = 0.;
+  fArea = 0.;
+  fPerimeter = 0.;
+  fHydraulicRadius = 0.;
+  fAreaRatio = 0.;
+  fElongation = 0.;
+  fCompactness = 0.;
+  fCircularity = 0.;
+  fComment = "";
+
+  delete fInspection;
+  fInspection = NULL;
+  
+  delete fType;
+  fType = NULL;
+
+  delete fContext;
+  fContext = NULL;
+
+  delete fImage;
+  fImage = NULL;
+}
+
+
+void StsDefect::Print()
+{
+  std::cout << "Sts Defect Instance:"                                          << std::endl;
+  std::cout << "   Defect Id                        = "    << fId              << std::endl;
+  std::cout << "   Inspection Id                    = "    << fInspectionId    << std::endl;
+  std::cout << "   Defect Type Id                   = "    << fTypeId          << std::endl;
+  std::cout << "   Defect Context Id                = "    << fContextId       << std::endl;
+  std::cout << "   Defect Finder Algorithm id       = "    << fAlgorithmId     << std::endl;
+  std::cout << "   Defect Image id                  = "    << fImageId         << std::endl;
+  std::cout << "   Left                             = "    << fLeft            << std::endl;
+  std::cout << "   Top                              = "    << fTop             << std::endl;
+  std::cout << "   Width                            = "    << fWidth           << std::endl;
+  std::cout << "   Height                           = "    << fHeight          << std::endl;
+  std::cout << "   Center of Mass X                 = "    << fCenterMassX     << std::endl;
+  std::cout << "   Center of Mass Y                 = "    << fCenterMassY     << std::endl;
+  std::cout << "   Area                             = "    << fArea            << std::endl;
+  std::cout << "   Perimeter                        = "    << fPerimeter       << std::endl;
+  std::cout << "   Hydraulic Radius                 = "    << fHydraulicRadius << std::endl;
+  std::cout << "   Defect area to Image area ratio  = "    << fAreaRatio       << std::endl;
+  std::cout << "   Elongation                       = "    << fElongation      << std::endl;
+  std::cout << "   Compactness                      = "    << fCompactness     << std::endl;
+  std::cout << "   Circularity                      = "    << fCircularity     << std::endl;
+  std::cout << "   Comment                          = "    << fComment         << std::endl;
+  std::cout                                                                    << std::endl;
+}
+
+StsDefect* StsDefect::GetDefectById(Int_t defectId, UInt_t runId)
+{
+  StsDefect defect;
+  FairDbReader<StsDefect> r_defect = *defect.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_defect.Activate(context, defect.GetVersion());
+  return (StsDefect *)r_defect.GetRowByIndex(defectId);
+}
+
+TObjArray* StsDefect::GetDefectsByImageId(Int_t inspectionImageId, UInt_t runId)
+{
+  StsDefect defect;
+  FairDbReader<StsDefect> r_defect;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_defect.Activate(context, defect.GetVersion());
+  Int_t numRows = r_defect.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  TObjArray* defects = new TObjArray(numRows);
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsDefect *def = (StsDefect*)r_defect.GetRow(i);
+    if (!def)
+      continue;
+
+    if (def->GetImageId() == inspectionImageId) {
+      defects->Add(def);
+    }
+  }
+
+  return defects;
+}
+
+TObjArray* StsDefect::GetDefectsByInspectionId(Int_t inspectionId, UInt_t runId)
+{
+  StsDefect defect;
+  FairDbReader<StsDefect> r_defect;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_defect.Activate(context, defect.GetVersion());
+  Int_t numRows = r_defect.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  TObjArray* defects = new TObjArray(numRows);
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsDefect *def = (StsDefect*)r_defect.GetRow(i);
+    if (!def)
+      continue;
+
+    if (def->GetInspectionId() == inspectionId)
+      defects->Add(def);
+  }
+
+  return defects;
+}
+
+string StsDefect::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO             INT NOT NULL,";
+  sql += "  ROW_ID            INT NOT NULL,";
+  sql += "  ID                INT NOT NULL,";
+  sql += "  INSPECTION_ID     INT NOT NULL,";
+  sql += "  TYPE_ID           INT NOT NULL,";
+  sql += "  CONTEXT_ID        INT NOT NULL,";
+  sql += "  ALGORITHM_ID      INT NOT NULL,";
+  sql += "  IMAGE_ID          INT NOT NULL,";
+  sql += "  LEFT              DOUBLE,";
+  sql += "  TOP               DOUBLE,";
+  sql += "  WIDTH             DOUBLE,";
+  sql += "  HEIGHT            DOUBLE,";
+  sql += "  CENTERMASS_X      DOUBLE,";
+  sql += "  CENTERMASS_Y      DOUBLE,";
+  sql += "  AREA              DOUBLE,";
+  sql += "  PERIMETER         DOUBLE,";
+  sql += "  HYDRAULIC_RADIUS  DOUBLE,";
+  sql += "  AREA_RATIO        DOUBLE,";
+  sql += "  ELONGATION        DOUBLE,";
+  sql += "  COMPACTNESS       DOUBLE,";
+  sql += "  CIRCULARITY       DOUBLE,";
+  sql += "  COMMENT           TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsDefect::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fInspectionId
+         >> fTypeId
+         >> fContextId
+         >> fAlgorithmId
+         >> fImageId
+         >> fLeft
+         >> fTop
+         >> fWidth
+         >> fHeight
+         >> fCenterMassX
+         >> fCenterMassY
+         >> fArea
+         >> fPerimeter
+         >> fHydraulicRadius
+         >> fAreaRatio
+         >> fElongation
+         >> fCompactness
+         >> fCircularity
+         >> fComment;
+}
+
+void StsDefect::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fInspectionId
+          << fTypeId
+          << fContextId
+          << fAlgorithmId
+          << fImageId
+          << fLeft
+          << fTop
+          << fWidth
+          << fHeight
+          << fCenterMassX
+          << fCenterMassY
+          << fArea
+          << fPerimeter
+          << fHydraulicRadius
+          << fAreaRatio
+          << fElongation
+          << fCompactness
+          << fCircularity
+          << fComment;
+}
+
+
+StsDefect::StsDefect(const StsDefect& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fInspectionId = from.fInspectionId;
+  fTypeId = from.fTypeId;
+  fContextId = from.fContextId;
+  fAlgorithmId = from.fAlgorithmId;
+  fImageId = from.fImageId;
+  fLeft = from.fLeft;
+  fTop = from.fTop;
+  fWidth = from.fWidth;
+  fHeight = from.fHeight;
+  fCenterMassX = from.fCenterMassX;
+  fCenterMassY = from.fCenterMassY;
+  fArea = from.fArea;
+  fPerimeter = from.fPerimeter;
+  fHydraulicRadius = from.fHydraulicRadius;
+  fAreaRatio = from.fAreaRatio;
+  fElongation = from.fElongation;
+  fCompactness = from.fCompactness;
+  fCircularity = from.fCircularity;
+  fComment = from.fComment;
+}
+
+StsDefect& StsDefect::operator=(const StsDefect& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fInspectionId = from.fInspectionId;
+  fTypeId = from.fTypeId;
+  fContextId = from.fContextId;
+  fAlgorithmId = from.fAlgorithmId;
+  fImageId = from.fImageId;
+  fLeft = from.fLeft;
+  fTop = from.fTop;
+  fWidth = from.fWidth;
+  fHeight = from.fHeight;
+  fCenterMassX = from.fCenterMassX;
+  fCenterMassY = from.fCenterMassY;
+  fArea = from.fArea;
+  fPerimeter = from.fPerimeter;
+  fHydraulicRadius = from.fHydraulicRadius;
+  fAreaRatio = from.fAreaRatio;
+  fElongation = from.fElongation;
+  fCompactness = from.fCompactness;
+  fCircularity = from.fCircularity;
+  fComment = from.fComment;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsDefect.h
+++ b/dbExamples/cbm_sts/src/StsDefect.h
@@ -1,0 +1,169 @@
+#ifndef STSDEFECT_H
+#define STSDEFECT_H
+
+#include "StsOpticalInspection.h"
+#include "StsDefectType.h"
+#include "StsDefectContext.h"
+#include "StsInspectionImage.h"
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsDefect : public FairDbGenericParSet<StsDefect>
+{
+
+using TObject::Compare;
+
+  public :
+    StsDefect(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsDefect", 
+              const char* title = "Sts Defect Type Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsDefect(void);
+    StsDefect(const StsDefect& from);
+    StsDefect& operator=(const StsDefect& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsDefect* GetDefectById(Int_t defectId, UInt_t runId = 0);
+    static TObjArray* GetDefectsByImageId(Int_t inspectionImageId, UInt_t runId = 0);
+    static TObjArray* GetDefectsByInspectionId(Int_t inspection, UInt_t runId = 0);
+
+
+    StsOpticalInspection* GetInspection() {
+      if (!fInspection) fInspection = StsOpticalInspection::GetInspectionById(fInspectionId);
+      return fInspection;
+    }
+
+    StsDefectType* GetType() {
+      if (!fType) fType = StsDefectType::GetDefectTypeById(fTypeId);
+      return fType;
+    }
+
+    StsDefectContext* GetContext() {
+      if (!fContext) fContext = StsDefectContext::GetDefectContextById(fContextId);
+      return fContext;
+    }
+
+    StsInspectionImage* GetImage() {
+      if (!fImage) fImage = StsInspectionImage::GetInspectionImageById(fImageId);
+      return fImage;
+    }
+
+    Int_t      GetId()                const { return fId; }
+    Int_t      GetInspectionId()      const { return fInspectionId; }
+    Int_t      GetTypeId()            const { return fTypeId; }
+    Int_t      GetContextId()         const { return fContextId; }
+    Int_t      GetAlgorithmId()       const { return fAlgorithmId; }
+    Int_t      GetImageId()           const { return fImageId; }
+    Double_t   GetLeft()              const { return fLeft; }
+    Double_t   GetTop()               const { return fTop; }
+    Double_t   GetWidth()             const { return fWidth; }
+    Double_t   GetHeight()            const { return fHeight; }
+    Double_t   GetCenterMassX()       const { return fCenterMassX; }
+    Double_t   GetCenterMassY()       const { return fCenterMassY; }
+    Double_t   GetArea()              const { return fArea; }
+    Double_t   GetPerimeter()         const { return fPerimeter; }
+    Double_t   GetHydraulicRadius()   const { return fHydraulicRadius; }
+    Double_t   GetAreaRatio()         const { return fAreaRatio; }
+    Double_t   GetElongation()        const { return fElongation; }
+    Double_t   GetCompactness()       const { return fCompactness; }
+    Double_t   GetCircularity()       const { return fCircularity; }
+    string     GetComment()           const { return fComment; }
+    
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetInspection(StsOpticalInspection& value) { fInspection = new StsOpticalInspection(value);
+                                                      fInspectionId = value.GetId(); }
+    void SetType(StsDefectType& value)              { fType = new StsDefectType(value);
+                                                      fTypeId = value.GetId(); }
+    void SetContext(StsDefectContext& value)        { fContext = new StsDefectContext(value);
+                                                      fContextId = value.GetId(); }
+    void SetImage(StsInspectionImage& value)        { fImage = new StsInspectionImage(value);
+                                                      fImageId = value.GetId(); }
+
+    void SetId(Int_t value)                 { fId = value; }
+    void SetInspectionId(Int_t value)       { fInspectionId = value; }
+    void SetTypeId(Int_t value)             { fTypeId = value; }
+    void SetContextId(Int_t value)          { fContextId = value; }
+    void SetAlgorithmId(Int_t value)        { fAlgorithmId = value; }
+    void SetImageId(Int_t value)            { fImageId = value; }
+    void SetLeft(Double_t value)            { fLeft = value; }
+    void SetTop(Double_t value)             { fTop = value; }
+    void SetWidth(Double_t value)           { fWidth = value; }
+    void SetHeight(Double_t value)          { fHeight = value; }
+    void SetCenterMassX(Double_t value)     { fCenterMassX = value; }
+    void SetCenterMassY(Double_t value)     { fCenterMassY = value; }
+    void SetArea(Double_t value)            { fArea = value; }
+    void SetPerimeter(Double_t value)       { fPerimeter = value; }
+    void SetHydraulicRadius(Double_t value) { fHydraulicRadius = value; }
+    void SetAreaRatio(Double_t value)       { fAreaRatio = value; }
+    void SetElongation(Double_t value)      { fElongation = value; }
+    void SetCompactness(Double_t value)     { fCompactness = value; }
+    void SetCircularity(Double_t value)     { fCircularity = value; }
+    void SetComment(string value)           { fComment = value; }
+
+
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    StsOpticalInspection* fInspection; //! Transient data member
+    StsDefectType*        fType;       //! Transient data member
+    StsDefectContext*     fContext;    //! Transient data member
+    StsInspectionImage*   fImage;      //! Transient data member
+
+    Int_t                 fId;
+    Int_t                 fInspectionId;
+    Int_t                 fTypeId;
+    Int_t                 fContextId;
+    Int_t                 fAlgorithmId;
+    Int_t                 fImageId;
+    Double_t              fLeft;
+    Double_t              fTop;
+    Double_t              fWidth;
+    Double_t              fHeight;
+    Double_t              fCenterMassX;
+    Double_t              fCenterMassY;
+    Double_t              fArea;
+    Double_t              fPerimeter;
+    Double_t              fHydraulicRadius;
+    Double_t              fAreaRatio;
+    Double_t              fElongation;
+    Double_t              fCompactness;
+    Double_t              fCircularity;
+    string                fComment;
+
+    ClassDef(StsDefect,1); // ROOT class definition
+};
+
+#endif /* !STSDEFECT_H*/
+

--- a/dbExamples/cbm_sts/src/StsDefectContext.cxx
+++ b/dbExamples/cbm_sts/src/StsDefectContext.cxx
@@ -1,0 +1,164 @@
+#include "StsDefectContext.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsDefectContext);
+
+static FairDbGenericParRegistry<StsDefectContext> sts("StsDefectContext", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsDefectContext>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsDefectContext>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsDefectContext>;
+
+StsDefectContext::StsDefectContext(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsDefectContext>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fContextName(""),
+  fWeight(0.)
+{
+
+}
+
+StsDefectContext::~StsDefectContext()
+{
+
+}
+
+void StsDefectContext::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsDefectContext::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("context_name", (Text_t*)&fContextName);
+  list->add("weight", (Text_t*)&fWeight);
+}
+
+Bool_t StsDefectContext::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+
+  Text_t context_name[MAX_TEXT_SIZE];
+  if (!list->fill("context_name", context_name, MAX_TEXT_SIZE))  {return kFALSE;}
+  fContextName = context_name;
+
+  if (!list->fill("weight", &fWeight)) {return kFALSE;}
+
+  return kTRUE;
+}
+
+void StsDefectContext::clear()
+{
+  fId = 0;
+  fContextName = "";
+  fWeight = 0.;
+}
+
+
+void StsDefectContext::Print()
+{
+  std::cout << "Sts Defect Type Instance:"                          << std::endl;
+  std::cout << "   Defect Type Id       = "     << fId              << std::endl;
+  std::cout << "   Defect Context Name  = "     << fContextName     << std::endl;
+  std::cout << "   Weight               = "     << fWeight          << std::endl;
+  std::cout                                                         << std::endl;
+}
+
+StsDefectContext* StsDefectContext::GetDefectContextById(Int_t contextId, UInt_t runId)
+{
+  StsDefectContext defcontext;
+  FairDbReader<StsDefectContext> r_defcontext = *defcontext.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_defcontext.Activate(context, defcontext.GetVersion());
+  return (StsDefectContext *)r_defcontext.GetRowByIndex(contextId);
+}
+
+string StsDefectContext::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO             INT NOT NULL,";
+  sql += "  ROW_ID            INT NOT NULL,";
+  sql += "  ID                INT NOT NULL,";
+  sql += "  CONTEXT_NAME      TEXT,";
+  sql += "  WEIGHT            DOUBLE,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsDefectContext::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fContextName
+         >> fWeight;
+}
+
+void StsDefectContext::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fContextName
+          << fWeight;
+}
+
+StsDefectContext::StsDefectContext(const StsDefectContext& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fContextName = from.fContextName;
+  fWeight = from.fWeight;
+}
+
+StsDefectContext& StsDefectContext::operator=(const StsDefectContext& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fContextName = from.fContextName;
+  fWeight = from.fWeight;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsDefectContext.h
+++ b/dbExamples/cbm_sts/src/StsDefectContext.h
@@ -1,0 +1,73 @@
+#ifndef STSDEFECTCONTEXT_H
+#define STSDEFECTCONTEXT_H
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsDefectContext : public FairDbGenericParSet<StsDefectContext>
+{
+
+using TObject::Compare;
+
+  public :
+    StsDefectContext(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsDefectContext", 
+              const char* title = "Sts Defect Context Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsDefectContext(void);
+    StsDefectContext(const StsDefectContext& from);
+    StsDefectContext& operator=(const StsDefectContext& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsDefectContext* GetDefectContextById(Int_t defectId, UInt_t runId = 0);
+
+    Int_t    GetId()              const { return fId; }
+    string   GetContextName()     const { return fContextName; }
+    Double_t GetWeight()          const { return fWeight; }
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetId(Int_t value)               { fId = value; }
+    void SetContextName(string value)     { fContextName = value; }
+    void SetWeight(Double_t value)        { fWeight = value; }
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    Int_t      fId;
+    string     fContextName;
+    Double_t   fWeight;
+
+    ClassDef(StsDefectContext,1); // ROOT class definition
+};
+
+#endif /* !STSDEFECTCONTEXT_H*/
+

--- a/dbExamples/cbm_sts/src/StsDefectType.cxx
+++ b/dbExamples/cbm_sts/src/StsDefectType.cxx
@@ -1,0 +1,164 @@
+#include "StsDefectType.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsDefectType);
+
+static FairDbGenericParRegistry<StsDefectType> sts("StsDefectType", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsDefectType>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsDefectType>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsDefectType>;
+
+StsDefectType::StsDefectType(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsDefectType>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fTypeName(""),
+  fWeight(0.)
+{
+
+}
+
+StsDefectType::~StsDefectType()
+{
+
+}
+
+void StsDefectType::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsDefectType::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("type_name", (Text_t*)&fTypeName);
+  list->add("weight", (Text_t*)&fWeight);
+}
+
+Bool_t StsDefectType::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+
+  Text_t type_name[MAX_TEXT_SIZE];
+  if (!list->fill("type_name", type_name, MAX_TEXT_SIZE))  {return kFALSE;}
+  fTypeName = type_name;
+
+  if (!list->fill("weight", &fWeight)) {return kFALSE;}
+
+  return kTRUE;
+}
+
+void StsDefectType::clear()
+{
+  fId = 0;
+  fTypeName = "";
+  fWeight = 0.;
+}
+
+
+void StsDefectType::Print()
+{
+  std::cout << "Sts Defect Type Instance:"                          << std::endl;
+  std::cout << "   Defect Type Id       = "     << fId              << std::endl;
+  std::cout << "   Defect Type Name     = "     << fTypeName        << std::endl;
+  std::cout << "   Weight               = "     << fWeight          << std::endl;
+  std::cout                                                         << std::endl;
+}
+
+StsDefectType* StsDefectType::GetDefectTypeById(Int_t typeId, UInt_t runId)
+{
+  StsDefectType type;
+  FairDbReader<StsDefectType> r_type = *type.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_type.Activate(context, type.GetVersion());
+  return (StsDefectType *)r_type.GetRowByIndex(typeId);
+}
+
+string StsDefectType::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO             INT NOT NULL,";
+  sql += "  ROW_ID            INT NOT NULL,";
+  sql += "  ID                INT NOT NULL,";
+  sql += "  TYPE_NAME         TEXT,";
+  sql += "  WEIGHT            DOUBLE,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsDefectType::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fTypeName
+         >> fWeight;
+}
+
+void StsDefectType::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fTypeName
+          << fWeight;
+}
+
+StsDefectType::StsDefectType(const StsDefectType& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fTypeName = from.fTypeName;
+  fWeight = from.fWeight;
+}
+
+StsDefectType& StsDefectType::operator=(const StsDefectType& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fTypeName = from.fTypeName;
+  fWeight = from.fWeight;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsDefectType.h
+++ b/dbExamples/cbm_sts/src/StsDefectType.h
@@ -1,0 +1,73 @@
+#ifndef STSDEFECTTYPE_H
+#define STSDEFECTTYPE_H
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsDefectType : public FairDbGenericParSet<StsDefectType>
+{
+
+using TObject::Compare;
+
+  public :
+    StsDefectType(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsDefectType", 
+              const char* title = "Sts Defect Type Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsDefectType(void);
+    StsDefectType(const StsDefectType& from);
+    StsDefectType& operator=(const StsDefectType& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsDefectType* GetDefectTypeById(Int_t defectTypId, UInt_t runId = 0);
+
+    Int_t    GetId()              const { return fId; }
+    string   GetTypeName()        const { return fTypeName; }
+    Double_t GetWeight()          const { return fWeight; }
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetId(Int_t value)               { fId = value; }
+    void SetTypeName(string value)        { fTypeName = value; }
+    void SetWeight(Double_t value)        { fWeight = value; }
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    Int_t      fId;
+    string     fTypeName;
+    Double_t   fWeight;
+
+    ClassDef(StsDefectType,1); // ROOT class definition
+};
+
+#endif /* !STSDEFECTTYPE_H*/
+

--- a/dbExamples/cbm_sts/src/StsInspectionImage.cxx
+++ b/dbExamples/cbm_sts/src/StsInspectionImage.cxx
@@ -1,0 +1,285 @@
+#include "StsInspectionImage.h"
+#include "StsDefect.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsInspectionImage);
+
+static FairDbGenericParRegistry<StsInspectionImage> sts("StsInspectionImage", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsInspectionImage>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsInspectionImage>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsInspectionImage>;
+
+StsInspectionImage::StsInspectionImage(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsInspectionImage>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fInspectionId(0),
+  fX(0),
+  fY(0),
+  fImageURI(""),
+  fThumbnailURI(""),
+  fOverlayURI("")
+{
+  fInspection = NULL;
+  fDefects = NULL;
+}
+
+StsInspectionImage::~StsInspectionImage()
+{
+  delete fInspection;
+  delete fDefects;
+}
+
+void StsInspectionImage::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsInspectionImage::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id",                        fId);
+  list->add("inspection_id",             fInspectionId);
+  list->add("x",                         fX);
+  list->add("y",                         fY);
+  list->add("image_uri",       (Text_t*)&fImageURI);
+  list->add("thumbnail_uri",   (Text_t*)&fThumbnailURI);
+  list->add("overlay_uri",     (Text_t*)&fOverlayURI);
+}
+
+Bool_t StsInspectionImage::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id",                 &fId))                     { return kFALSE; }
+  if (!list->fill("inspection_id",      &fInspectionId))           { return kFALSE; }
+  if (!list->fill("x",                  &fX))                      { return kFALSE; }
+  if (!list->fill("y",                  &fY))                      { return kFALSE; }
+
+  Text_t image_uri[MAX_TEXT_SIZE];
+  if (!list->fill("image_uri", image_uri, MAX_TEXT_SIZE))          { return kFALSE; }
+  fImageURI = image_uri;
+
+  Text_t thumbnail_uri[MAX_TEXT_SIZE];
+  if (!list->fill("thumbnail_uri", thumbnail_uri, MAX_TEXT_SIZE))  { return kFALSE; }
+  fThumbnailURI = thumbnail_uri;
+
+  Text_t overlay_uri[MAX_TEXT_SIZE];
+  if (!list->fill("overlay_uri", overlay_uri, MAX_TEXT_SIZE))      { return kFALSE; }
+  fOverlayURI = overlay_uri;
+  return kTRUE;
+}
+
+void StsInspectionImage::clear()
+{
+  fId = 0;
+  fInspectionId = 0;
+  fX = 0;
+  fY = 0;
+  fImageURI = "";
+  fThumbnailURI = "";
+  fOverlayURI = "";
+
+  delete fInspection;
+  fInspection = NULL;
+
+  delete fDefects;
+  fDefects = NULL;
+}
+
+void StsInspectionImage::Print()
+{
+  std::cout << "Sts Inspection Image Instance:"                   << std::endl;
+  std::cout << "   Image Id             = "    << fId             << std::endl;
+  std::cout << "   Inspection Id        = "    << fInspectionId   << std::endl;
+  std::cout << "   ROI X                = "    << fX              << std::endl;
+  std::cout << "   ROI Y                = "    << fY              << std::endl;
+  std::cout << "   Image URI            = "    << fImageURI       << std::endl;
+  std::cout << "   Thumbnail URI        = "    << fThumbnailURI   << std::endl;
+  std::cout << "   Overlay URI          = "    << fOverlayURI     << std::endl;
+  std::cout                                                       << std::endl;
+}
+
+StsInspectionImage* StsInspectionImage::GetInspectionImageById(Int_t inspectionImageId, UInt_t runId)
+{
+  StsInspectionImage image;
+  FairDbReader<StsInspectionImage> r_image = *image.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_image.Activate(context, image.GetVersion());
+  return (StsInspectionImage *)r_image.GetRowByIndex(inspectionImageId);
+}
+
+
+StsInspectionImage* StsInspectionImage::GetInspectionImage(Int_t inspectionId, Int_t X, Int_t Y, UInt_t runId)
+{
+  StsInspectionImage image;
+  FairDbReader<StsInspectionImage> r_image;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_image.Activate(context, image.GetVersion());
+  Int_t numRows = r_image.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsInspectionImage *img = (StsInspectionImage*)r_image.GetRow(i);
+    if (!img)
+      continue;
+
+    if (img->GetInspectionId() == inspectionId && img->GetX() == X && img->GetY() == Y)
+      return img;
+  }
+
+  return NULL;
+}
+
+TObjArray* StsInspectionImage::GetInspectionImages(Int_t inspectionId, UInt_t runId)
+{
+  StsInspectionImage image;
+  FairDbReader<StsInspectionImage> r_image;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_image.Activate(context, image.GetVersion());
+  Int_t numRows = r_image.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  TObjArray* images = new TObjArray(numRows);
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsInspectionImage *img = (StsInspectionImage*)r_image.GetRow(i);
+    if (!img)
+      continue;
+
+    if (img->GetInspectionId() == inspectionId)
+      images->Add(img);
+  }
+
+  return images;
+}
+
+StsOpticalInspection* StsInspectionImage::GetInspection() {
+  if (!fInspection) fInspection = StsOpticalInspection::GetInspectionById(fInspectionId);
+  return fInspection;
+}
+
+TObjArray* StsInspectionImage::GetDefects() {
+  if (!fDefects) fDefects = StsDefect::GetDefectsByImageId(fId);
+  return fDefects;
+}
+
+
+string StsInspectionImage::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO             INT NOT NULL,";
+  sql += "  ROW_ID            INT NOT NULL,";
+  sql += "  ID                INT NOT NULL,";
+  sql += "  INSPECTION_ID     INT NOT NULL,";
+  sql += "  X                 INT,";
+  sql += "  Y                 INT,";
+  sql += "  IMAGE_URI         TEXT,";
+  sql += "  THUMBNAIL_URI     TEXT,";
+  sql += "  OVERLAY_URI       TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsInspectionImage::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in  >> fId
+          >> fInspectionId
+          >> fX
+          >> fY
+          >> fImageURI
+          >> fThumbnailURI
+          >> fOverlayURI;
+}
+
+void StsInspectionImage::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fInspectionId
+          << fX
+          << fY
+          << fImageURI
+          << fThumbnailURI
+          << fOverlayURI;
+}
+
+StsInspectionImage::StsInspectionImage(const StsInspectionImage& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fInspectionId = from.fInspectionId;
+  fX = from.fX;
+  fY = from.fY;
+  fImageURI = from.fImageURI;
+  fThumbnailURI = from.fThumbnailURI;
+  fOverlayURI = from.fOverlayURI;
+}
+
+StsInspectionImage& StsInspectionImage::operator=(const StsInspectionImage& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fInspectionId = from.fInspectionId;
+  fX = from.fX;
+  fY = from.fY;
+  fImageURI = from.fImageURI;
+  fThumbnailURI = from.fThumbnailURI;
+  fOverlayURI = from.fOverlayURI;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsInspectionImage.h
+++ b/dbExamples/cbm_sts/src/StsInspectionImage.h
@@ -1,0 +1,99 @@
+#ifndef STSINSPECTIONIMAGE_H
+#define STSINSPECTIONIMAGE_H
+
+#include "StsOpticalInspection.h"
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsInspectionImage : public FairDbGenericParSet<StsInspectionImage>
+{
+
+using TObject::Compare;
+
+  public :
+    StsInspectionImage(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsInspectionImage", 
+              const char* title = "Sts Defect Type Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsInspectionImage(void);
+    StsInspectionImage(const StsInspectionImage& from);
+    StsInspectionImage& operator=(const StsInspectionImage& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsInspectionImage* GetInspectionImageById(Int_t inspectionImageId, UInt_t runId = 0);
+    static StsInspectionImage* GetInspectionImage(Int_t inspectionId, Int_t X, Int_t Y, UInt_t runId = 0);
+    static TObjArray* GetInspectionImages(Int_t inspectionId, UInt_t runId = 0);
+
+
+    StsOpticalInspection* GetInspection();
+    TObjArray*            GetDefects();
+
+    Int_t    GetId()                    const { return fId; }
+    Int_t    GetInspectionId()          const { return fInspectionId; }
+    Int_t    GetX()                     const { return fX; }
+    Int_t    GetY()                     const { return fY; }
+    string   GetImageURI()              const { return fImageURI; }
+    string   GetThumbnailURI()          const { return fThumbnailURI; }
+    string   GetOverlayURI()            const { return fOverlayURI; }
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetInspection(StsOpticalInspection &value)   { fInspection = new StsOpticalInspection(value); 
+                                                        SetInspectionId(value.GetId()); }
+
+    void SetId(Int_t  value)                         { fId = value; }
+    void SetInspectionId(Int_t  value)               { fInspectionId = value; }
+    void SetX(Int_t  value)                          { fX = value; }
+    void SetY(Int_t  value)                          { fY = value; }
+    void SetImageURI(string value)                   { fImageURI = value; }
+    void SetThumbnailURI(string value)               { fThumbnailURI = value; }
+    void SetOverlayURI(string value)                 { fOverlayURI = value; }
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    StsOpticalInspection* fInspection; //! Transient data member
+    TObjArray*            fDefects;    //! Transient data member, might be NULL or empty in case of no defects
+
+    Int_t                 fId;
+    Int_t                 fInspectionId;
+    Int_t                 fX;
+    Int_t                 fY;
+    string                fImageURI;
+    string                fThumbnailURI;
+    string                fOverlayURI;
+
+    ClassDef(StsInspectionImage,1); // ROOT class definition
+};
+
+#endif /* !STSINSPECTIONIMAGE_H*/
+

--- a/dbExamples/cbm_sts/src/StsOpticalInspection.cxx
+++ b/dbExamples/cbm_sts/src/StsOpticalInspection.cxx
@@ -1,0 +1,339 @@
+#include "StsOpticalInspection.h"
+#include "StsInspectionImage.h"
+#include "StsDefect.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsOpticalInspection);
+
+static FairDbGenericParRegistry<StsOpticalInspection> sts("StsOpticalInspection", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsOpticalInspection>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsOpticalInspection>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsOpticalInspection>;
+
+
+StsOpticalInspection::StsOpticalInspection(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsOpticalInspection>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fSensorId(0),
+  fSizeX(0),
+  fSizeY(0),
+  fDate(ValTimeStamp::GetBOT()),
+  fSensorSide(""),
+  fMaxWarp(0.),
+  fThickness(0.),
+  fQuality(0.),
+  fQualityGrade(""),
+  fPassed(kFALSE),
+  fComment("")
+{
+  fSensor = NULL;
+  fInspectionImages = NULL;
+  fDefects = NULL;
+  fWarp = new TObject();
+}
+
+StsOpticalInspection::~StsOpticalInspection()
+{
+  delete fSensor;
+  delete fInspectionImages;
+  delete fDefects;
+  delete fWarp;
+}
+
+void StsOpticalInspection::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsOpticalInspection::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("inspection_id", fId);
+  list->add("sensor_id", fSensorId);
+  list->add("size_x", fSizeX);
+  list->add("size_y", fSizeY);
+  list->add("date", FairDb::MakeDateTimeString(fDate).Data());
+  list->add("sensor_side",     (Text_t*)&fSensorSide);
+  list->add("max_warp", fMaxWarp);
+  list->addObject("warp", fWarp);
+  list->add("thickness", fThickness);
+  list->add("quality", fQuality);
+  list->add("quality_grade", (Text_t*)&fQualityGrade);
+  list->add("passed", fPassed);
+  list->add("comment", (Text_t*)&fComment);
+}
+
+Bool_t StsOpticalInspection::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("inspection_id", &fId))  {return kFALSE;}
+  if (!list->fill("sensor_id", &fSensorId))  {return kFALSE;}
+  if (!list->fill("size_x", &fSizeX))  {return kFALSE;}
+  if (!list->fill("size_y", &fSizeY))  {return kFALSE;}
+
+  Text_t date[MAX_TEXT_SIZE];
+  if (!list->fill("date", date, MAX_TEXT_SIZE)) {return kFALSE;}
+  fDate = FairDb::MakeTimeStamp(date);
+
+  Text_t sensor_side[MAX_TEXT_SIZE];
+  if (!list->fill("sensor_side", sensor_side, MAX_TEXT_SIZE))  {return kFALSE;}
+  fSensorSide = sensor_side;
+
+  if (!list->fill("max_warp", &fMaxWarp))  {return kFALSE;}
+  if (!list->fillObject("warp", fWarp))  {return kFALSE;}
+  if (!list->fill("thickness", &fThickness))  {return kFALSE;}
+  if (!list->fill("quality", &fQuality)) {return kFALSE;}
+
+  Text_t quality_grade[MAX_TEXT_SIZE];
+  if (!list->fill("quality_grade", quality_grade, MAX_TEXT_SIZE))     {return kFALSE;}
+  fQualityGrade = quality_grade;
+
+  if (!list->fill("passed", &fPassed))  {return kFALSE;}
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))     {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsOpticalInspection::clear()
+{
+  fId = 0;
+  fSensorId = 0;
+  fSizeX = 0;
+  fSizeY = 0;
+  fDate = ValTimeStamp::GetBOT();
+  fSensorSide = "";
+  fMaxWarp = 0.;
+  fThickness = 0.;
+  fQuality = 0.;
+  fQualityGrade = "";
+  fPassed = kFALSE;
+  fComment = "";
+
+  delete fSensor;
+  fSensor = NULL;
+
+  delete fInspectionImages;
+  fInspectionImages = NULL;
+
+  delete fDefects;
+  fInspectionImages = NULL;
+
+  delete fWarp;
+  fWarp = NULL;
+}
+
+void StsOpticalInspection::Print()
+{
+  std::cout << "Sts Sensor Optical Inspection Instance:"         << std::endl;
+  std::cout << "   Inspection Id          = "   << fId           << std::endl;
+  std::cout << "   Sensor Id              = "   << fSensorId     << std::endl;
+  std::cout << "   Size X                 = "   << fSizeX        << std::endl;
+  std::cout << "   Size Y                 = "   << fSizeY        << std::endl;
+  std::cout << "   Date                   = "   << fDate         << std::endl;
+  std::cout << "   Sensor Side            = "   << fSensorSide   << std::endl;
+  std::cout << "   Maximal Warp           = "   << fMaxWarp      << std::endl;
+  std::cout << "   Warp                   = "   << fWarp         << std::endl;
+  std::cout << "   Thickness              = "   << fThickness    << std::endl;
+  std::cout << "   Quality                = "   << fQuality      << std::endl;
+  std::cout << "   Quality Grade          = "   << fQualityGrade << std::endl;
+  std::cout << "   Passed                 = "   << fPassed       << std::endl;
+  std::cout << "   Comment                = "   << fComment      << std::endl;
+  std::cout                                                      << std::endl;
+}
+
+StsSensor* StsOpticalInspection::GetSensor() {
+  if (!fSensor) fSensor = StsSensor::GetSensorById(fSensorId);
+  return fSensor;
+}
+
+TObjArray* StsOpticalInspection::GetInspectionImages() {
+  if (!fInspectionImages) fInspectionImages = StsInspectionImage::GetInspectionImages(fId);
+  return fInspectionImages;
+}
+
+TObjArray* StsOpticalInspection::GetDefects() {
+  if (!fDefects) fDefects = StsDefect::GetDefectsByInspectionId(fId);
+  return fDefects;
+}
+
+StsOpticalInspection* StsOpticalInspection::GetInspectionById(Int_t inspectionId, UInt_t runId)
+{
+  StsOpticalInspection inspection;
+  FairDbReader<StsOpticalInspection> r_inspection = *inspection.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_inspection.Activate(context, inspection.GetVersion());
+  return (StsOpticalInspection *)r_inspection.GetRowByIndex(inspectionId);
+}
+
+TObjArray* StsOpticalInspection::GetInspections(Int_t sensorId, UInt_t runId)
+{
+  StsOpticalInspection inspection;
+  FairDbReader<StsOpticalInspection> r_inspection;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_inspection.Activate(context, inspection.GetVersion());
+  Int_t numRows = r_inspection.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  TObjArray* inspections = new TObjArray(numRows);
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsOpticalInspection *insp = (StsOpticalInspection*)r_inspection.GetRow(i);
+    if (!insp)
+      continue;
+
+    if (insp->GetSensorId() == sensorId)
+      inspections->Add(insp);
+  }
+
+  return inspections;
+}
+
+string StsOpticalInspection::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO           INT NOT NULL,";
+  sql += "  ROW_ID          INT NOT NULL,";
+  sql += "  INSPECTION_ID   INT NOT NULL,";
+  sql += "  SENSOR_ID       INT NOT NULL,";
+  sql += "  SIZE_X          INT,";
+  sql += "  SIZE_Y          INT,";
+  sql += "  DATE            DATETIME,";
+  sql += "  SENSOR_SIDE     TEXT,";
+  sql += "  MAX_WARP        DOUBLE,";
+  sql += "  WARP            TEXT,";
+  sql += "  THICKNESS       DOUBLE,";
+  sql += "  QUALITY         DOUBLE,";
+  sql += "  QUALITY_GRADE   TEXT,";
+  sql += "  PASSED          INT,";
+  sql += "  COMMENT         TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,INSPECTION_ID))";
+  return sql;
+}
+
+void StsOpticalInspection::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  FairDbStreamer warpStreamer(fWarp);
+  res_in >> fId
+         >> fSensorId
+         >> fSizeX
+         >> fSizeY
+         >> fDate
+         >> fSensorSide
+         >> fMaxWarp
+         >> warpStreamer
+         >> fThickness
+         >> fQuality
+         >> fQualityGrade
+         >> fPassed
+         >> fComment;
+}
+
+void StsOpticalInspection::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{  
+  FairDbStreamer warpStreamer(fWarp);
+  res_out << fId
+          << fSensorId
+          << fSizeX
+          << fSizeY
+          << fDate
+          << fSensorSide
+          << fMaxWarp
+          << warpStreamer
+          << fThickness
+          << fQuality
+          << fQualityGrade
+          << fPassed
+          << fComment;
+
+  warpStreamer.Fill(fWarp);
+}
+
+StsOpticalInspection::StsOpticalInspection(const StsOpticalInspection& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fSensorId = from.fSensorId;
+  fSizeX = from.fSizeX;
+  fSizeY = from.fSizeY;
+  fDate = from.fDate;
+  fSensorSide = from.fSensorSide;
+  fMaxWarp = from.fMaxWarp;
+  fWarp = from.fWarp;
+  fThickness = from.fThickness;
+  fQuality = from.fQuality;
+  fQualityGrade = from.fQualityGrade;
+  fPassed = from.fPassed;
+  fComment = from.fComment;
+}
+
+StsOpticalInspection& StsOpticalInspection::operator=(const StsOpticalInspection& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fSensorId = from.fSensorId;
+  fSizeX = from.fSizeX;
+  fSizeY = from.fSizeY;
+  fDate = from.fDate;
+  fSensorSide = from.fSensorSide;
+  fMaxWarp = from.fMaxWarp;
+  fWarp = from.fWarp;
+  fThickness = from.fThickness;
+  fQuality = from.fQuality;
+  fQualityGrade = from.fQualityGrade;
+  fPassed = from.fPassed;
+  fComment = from.fComment;
+
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsOpticalInspection.h
+++ b/dbExamples/cbm_sts/src/StsOpticalInspection.h
@@ -1,0 +1,121 @@
+#ifndef STSOPTICALINSPECTION_H
+#define STSOPTICALINSPECTION_H
+
+#include "StsSensor.h"
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+#include "TObjArray.h"
+
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsOpticalInspection : public FairDbGenericParSet<StsOpticalInspection>
+{
+
+using TObject::Compare;
+
+  public :
+    StsOpticalInspection(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsOpticalInspection", 
+              const char* title = "Sts Sensor Optical Inspection Entity", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsOpticalInspection(void);
+    StsOpticalInspection(const StsOpticalInspection& from);
+    StsOpticalInspection& operator=(const StsOpticalInspection& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    StsSensor* GetSensor();
+    TObjArray* GetInspectionImages();
+    TObjArray* GetDefects();
+
+    static StsOpticalInspection* GetInspectionById(Int_t inspectionId, UInt_t runId = 0);
+    static TObjArray* GetInspections(Int_t sensorId, UInt_t runId = 0);
+
+
+    Int_t GetId()            const { return fId; }
+    Int_t GetSensorId()      const { return fSensorId; }
+    Int_t GetSizeX()         const { return fSizeX; }
+    Int_t GetSizeY()         const { return fSizeY; }
+    ValTimeStamp GetDate()   const { return fDate; }
+    string GetSensorSide()   const { return fSensorSide; }
+    Double_t GetMaxWarp()    const { return fMaxWarp; }
+    TObject* GetWarp()       const { return fWarp; }
+    Double_t GetThickness()  const { return fThickness; }
+    Double_t GetQuality()    const { return fQuality; }
+    string GetQualityGrade() const { return fQualityGrade; }
+    Int_t GetPassed()        const { return fPassed; }
+    string GetComment()      const { return fComment; } 
+
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetSensor(StsSensor &value)   { fSensor = new StsSensor(value); SetSensorId(value.GetId()); }
+
+    void SetId(Int_t value)            { fId = value; }
+    void SetSensorId(Int_t value)      { fSensorId = value; }
+    void SetSizeX(Int_t value)         { fSizeX = value; }
+    void SetSizeY(Int_t value)         { fSizeY = value; }
+    void SetDate(ValTimeStamp value)   { fDate = value; }
+    void SetSensorSide(string value)   { fSensorSide = value; }
+    void SetMaxWarp(Double_t value)    { fMaxWarp = value; }
+    void SetWarp(TObject* value)       { if (fWarp) delete fWarp; fWarp = value ? value->Clone() : NULL; }
+    void SetThickness(Double_t value)  { fThickness = value; }
+    void SetQuality(Double_t value)    { fQuality = value; } 
+    void SetQualityGrade(string value) { fQualityGrade = value; }
+    void SetPassed(Int_t value)        { fPassed = value; }
+    void SetComment(string value)      { fComment = value; }
+
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    StsSensor *fSensor;           //! Transient data member
+    TObjArray *fInspectionImages; //! Transient data member
+    TObjArray *fDefects;          //! Transient data member
+
+    Int_t fId;
+    Int_t fSensorId;
+    Int_t fSizeX;
+    Int_t fSizeY;
+    ValTimeStamp fDate;
+    string fSensorSide;
+    Double_t fMaxWarp;
+    TObject* fWarp;
+    Double_t fThickness;
+    Double_t fQuality;
+    string fQualityGrade;
+    Int_t fPassed;
+    string fComment;
+
+    ClassDef(StsOpticalInspection,1); // ROOT class definition
+};
+
+#endif /* !STSOPTICALINSPECTION_H*/
+

--- a/dbExamples/cbm_sts/src/StsSensor.cxx
+++ b/dbExamples/cbm_sts/src/StsSensor.cxx
@@ -1,0 +1,318 @@
+#include "StsSensor.h"
+#include "StsOpticalInspection.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsSensor);
+
+static FairDbGenericParRegistry<StsSensor> sts("StsSensor", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsSensor>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsSensor>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsSensor>;
+
+
+StsSensor::StsSensor(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsSensor>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fBatchId(0),
+  fLocationId(0),
+  fTypeId(0),
+  fVendorId(0),
+  fReticleName(""),
+  fWaferNumber(0),
+  fDate(ValTimeStamp::GetBOT()),
+  fQuality(0.),
+  fQualityGrade(""),
+  fComment("")
+{
+  fOpticalInspections = NULL;
+  fBatch = NULL;
+  fLocation = NULL;
+  fType = NULL;
+  fVendor = NULL;
+}
+
+StsSensor::~StsSensor()
+{
+  delete fOpticalInspections;
+  delete fBatch;
+  delete fLocation;
+  delete fType;
+  delete fVendor;
+}
+
+void StsSensor::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsSensor::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("batch_id", fBatchId);
+  list->add("location_id", fLocationId);
+  list->add("type_id", fTypeId);
+  list->add("vendor_id", fVendorId);
+  list->add("reticle_name", (Text_t*)&fReticleName);
+  list->add("wafer_number", fWaferNumber);
+  list->add("date", FairDb::MakeDateTimeString(fDate).Data());
+  list->add("quality", fQuality);
+  list->add("quality_grade", (Text_t*)&fQualityGrade);
+  list->add("comment", (Text_t*)&fComment);
+}
+
+Bool_t StsSensor::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+  if (!list->fill("batch_id", &fBatchId))  {return kFALSE;}
+  if (!list->fill("location_id", &fLocationId))  {return kFALSE;}
+  if (!list->fill("type_id", &fTypeId))  {return kFALSE;}
+  if (!list->fill("vendor_id", &fVendorId))  {return kFALSE;}
+
+  Text_t reticle_name[MAX_TEXT_SIZE];
+  if (!list->fill("reticle_name", reticle_name, MAX_TEXT_SIZE)) {return kFALSE;}
+  fReticleName = reticle_name;
+
+  if (!list->fill("wafer_number", &fWaferNumber)) {return kFALSE;}
+  
+  Text_t date[MAX_TEXT_SIZE];
+  if (!list->fill("date", date, MAX_TEXT_SIZE)) {return kFALSE;}
+  fDate = FairDb::MakeTimeStamp(date);
+  
+  if (!list->fill("quality", &fQuality)) {return kFALSE;}
+
+  Text_t quality_grade[MAX_TEXT_SIZE];
+  if (!list->fill("quality_grade", quality_grade, MAX_TEXT_SIZE)) {return kFALSE;}
+  fQualityGrade = quality_grade;
+
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))     {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsSensor::clear()
+{
+  fId = 0;
+  fBatchId = 0;
+  fLocationId = 0;
+  fTypeId = 0;
+  fVendorId = 0;
+  fReticleName = "";
+  fWaferNumber = 0;
+  fDate = ValTimeStamp::GetBOT();
+  fQuality = 0.;
+  fQualityGrade = "";
+  fComment = "";
+
+  delete fOpticalInspections;
+  fOpticalInspections = NULL;
+
+  delete fBatch;
+  fBatch = NULL;
+
+  delete fLocation;
+  fLocation = NULL;
+
+  delete fType;
+  fType = NULL;
+
+  delete fVendor;
+  fVendor = NULL;
+}
+
+
+void StsSensor::Print()
+{
+  std::cout << "Sts Sensor Instance:"                       << std::endl;
+  std::cout << "   Sensor Id     = "     << fId             << std::endl;
+  std::cout << "   Batch Id      = "     << fBatchId        << std::endl;
+  std::cout << "   Location Id   = "     << fLocationId     << std::endl;
+  std::cout << "   Type Id       = "     << fTypeId         << std::endl;
+  std::cout << "   Vendor Id     = "     << fVendorId       << std::endl;
+  std::cout << "   Reticle name  = "     << fReticleName    << std::endl;
+  std::cout << "   Wafer Number  = "     << fWaferNumber    << std::endl;
+  std::cout << "   Date          = "     << fDate           << std::endl;
+  std::cout << "   Quality       = "     << fQuality        << std::endl;
+  std::cout << "   Quality Grade = "     << fQualityGrade   << std::endl;
+  std::cout << "   Comment       = "     << fComment        << std::endl;
+  std::cout                                                 << std::endl;
+}
+
+StsSensor* StsSensor::GetSensorById(Int_t sensorId, UInt_t runId)
+{
+  StsSensor sensor;
+  FairDbReader<StsSensor> r_sensor = *sensor.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_sensor.Activate(context, sensor.GetVersion());
+  return (StsSensor *)r_sensor.GetRowByIndex(sensorId);
+}
+
+TObjArray* StsSensor::GetSensors(Int_t batchId, UInt_t runId)
+{
+  StsSensor sensor;
+  FairDbReader<StsSensor> r_sensor;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_sensor.Activate(context, sensor.GetVersion());
+  Int_t numRows = r_sensor.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  TObjArray* sensors = new TObjArray(numRows);
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsSensor *sens = (StsSensor*)r_sensor.GetRow(i);
+    if (!sens)
+      continue;
+
+    if (sens->GetBatchId() == batchId)
+      sensors->Add(sens);
+  }
+
+  return sensors;
+}
+
+TObjArray* StsSensor::GetOpticalInspections()
+{
+  if (!fOpticalInspections)
+  {
+    fOpticalInspections = StsOpticalInspection::GetInspections(fId);
+  }
+
+  return fOpticalInspections;
+}
+
+string StsSensor::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO           INT NOT NULL,";
+  sql += "  ROW_ID          INT NOT NULL,";
+  sql += "  ID              INT,";
+  sql += "  BATCH_ID        INT,";
+  sql += "  LOCATION_ID     INT,";
+  sql += "  TYPE_ID         INT,";
+  sql += "  VENDOR_ID       INT,";
+  sql += "  RETICLE_NAME    TEXT,";
+  sql += "  WAFER_NUMBER    INT,";
+  sql += "  DATE            DATETIME,";
+  sql += "  QUALITY         DOUBLE,";
+  sql += "  QUALITY_GRADE   TEXT,";
+  sql += "  COMMENT         TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID))";
+  return sql;
+}
+
+void StsSensor::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fBatchId
+         >> fLocationId
+         >> fTypeId
+         >> fVendorId
+         >> fReticleName
+         >> fWaferNumber
+         >> fDate
+         >> fQuality
+         >> fQualityGrade
+         >> fComment;
+}
+
+void StsSensor::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fBatchId
+          << fLocationId
+          << fTypeId
+          << fVendorId
+          << fReticleName
+          << fWaferNumber
+          << fDate
+          << fQuality
+          << fQualityGrade
+          << fComment;
+}
+
+StsSensor::StsSensor(const StsSensor& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fBatchId = from.fBatchId;
+  fLocationId = from.fLocationId;
+  fTypeId = from.fTypeId;
+  fVendorId = from.fVendorId;
+  fReticleName = from.fReticleName;
+  fWaferNumber = from.fWaferNumber;
+  fDate = from.fDate;
+  fQuality = from.fQuality;
+  fQualityGrade = from.fQualityGrade;
+  fComment = from.fComment;
+}
+
+StsSensor& StsSensor::operator=(const StsSensor& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fBatchId = from.fBatchId;
+  fLocationId = from.fLocationId;
+  fTypeId = from.fTypeId;
+  fVendorId = from.fVendorId;
+  fReticleName = from.fReticleName;
+  fWaferNumber = from.fWaferNumber;
+  fDate = from.fDate;
+  fQuality = from.fQuality;
+  fQualityGrade = from.fQualityGrade;
+  fComment = from.fComment;
+
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsSensor.h
+++ b/dbExamples/cbm_sts/src/StsSensor.h
@@ -1,0 +1,138 @@
+#ifndef STSSENSOR_H
+#define STSSENSOR_H
+
+#include "StsSensorBatch.h"
+#include "StsSensorLocation.h"
+#include "StsSensorType.h"
+#include "StsSensorVendor.h"
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsSensor : public FairDbGenericParSet<StsSensor>
+{
+
+using TObject::Compare;
+
+  public :
+    StsSensor(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsSensor", 
+              const char* title = "Sts Sensor Entity", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsSensor(void);
+    StsSensor(const StsSensor& from);
+    StsSensor& operator=(const StsSensor& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsSensor* GetSensorById(Int_t sensorId, UInt_t runId = 0);
+    static TObjArray* GetSensors(Int_t batchId, UInt_t runId = 0);
+    
+    StsSensorBatch* GetBatch() {
+      if (!fBatch) fBatch = StsSensorBatch::GetBatchById(fBatchId);
+      return fBatch;
+    }
+
+    TObjArray* GetOpticalInspections();
+
+    StsSensorLocation* GetLocation() {
+      if (!fLocation) fLocation = StsSensorLocation::GetLocationById(fLocationId);
+      return fLocation;
+    }
+
+    StsSensorType* GetType() {
+      if (!fType) fType = StsSensorType::GetTypeById(fTypeId);
+      return fType;
+    }
+
+    StsSensorVendor* GetVendor() {
+      if (!fVendor) fVendor = StsSensorVendor::GetVendorById(fVendorId);
+      return fVendor;
+    }
+
+    Int_t  GetId()           const { return fId; }
+    Int_t  GetBatchId()      const { return fBatchId; }
+    Int_t  GetLocationId()   const { return fLocationId; }
+    Int_t  GetTypeId()       const { return fTypeId; }
+    Int_t  GetVendorId()     const { return fVendorId; }
+    string GetReticleName()  const { return fReticleName; }
+    Int_t  GetWaferNumber()  const { return fWaferNumber; }
+    ValTimeStamp GetDate()   const { return fDate; }
+    Double_t GetQuality()    const { return fQuality; }
+    string GetQualityGrade() const { return fQualityGrade; }
+    string GetComment()      const { return fComment; }
+
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetBatch(StsSensorBatch& value)             { fBatch = new StsSensorBatch(value); fBatchId = value.GetId(); }
+    void SetLocation(StsSensorLocation& value) { fLocation = new StsSensorLocation(value); fLocationId = value.GetId(); }
+    void SetType(StsSensorType& value)         { fType = new StsSensorType(value); fTypeId = value.GetId(); }
+    void SetVendor(StsSensorVendor& value)           { fVendor = new StsSensorVendor(value); fVendorId = value.GetId(); }
+
+    void SetId(Int_t value)            { fId = value; }
+    void SetBatchId(Int_t value)       { fBatchId = value; }
+    void SetLocationId(Int_t value)    { fLocationId = value; }
+    void SetTypeId(Int_t value)        { fTypeId = value; }
+    void SetVendorId(Int_t value)      { fVendorId = value; }
+    void SetReticleName(string value)  { fReticleName = value; }
+    void SetWaferNumber(Int_t value)   { fWaferNumber = value; }
+    void SetDate(ValTimeStamp value)   { fDate = value; }
+    void SetQuality(Double_t value)    { fQuality = value; }
+    void SetQualityGrade(string value) { fQualityGrade = value; }
+    void SetComment(string value)      { fComment = value; }
+
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    TObjArray*         fOpticalInspections; //! Transient data member
+    StsSensorBatch*    fBatch;              //! Transient data member
+    StsSensorLocation* fLocation;           //! Transient data member
+    StsSensorType*     fType;               //! Transient data member
+    StsSensorVendor*   fVendor;             //! Transient data member
+
+    Int_t              fId;
+    Int_t              fBatchId;
+    Int_t              fLocationId;
+    Int_t              fTypeId;
+    Int_t              fVendorId;
+    string             fReticleName;
+    Int_t              fWaferNumber;
+    ValTimeStamp       fDate;
+    Double_t           fQuality;
+    string             fQualityGrade;
+    string             fComment;
+
+    ClassDef(StsSensor,1); // ROOT class definition
+};
+
+#endif /* !STSSENSOR_H*/
+

--- a/dbExamples/cbm_sts/src/StsSensorBatch.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorBatch.cxx
@@ -1,0 +1,193 @@
+#include "StsSensorBatch.h"
+#include "StsSensor.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsSensorBatch);
+
+static FairDbGenericParRegistry<StsSensorBatch> sts("StsSensorBatch", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsSensorBatch>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsSensorBatch>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsSensorBatch>;
+
+StsSensorBatch::StsSensorBatch(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsSensorBatch>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fNumber(""),
+  fDate(ValTimeStamp::GetBOT()),
+  fComment("")
+{
+  fSensors = NULL;
+}
+
+StsSensorBatch::~StsSensorBatch()
+{
+  delete fSensors;
+}
+
+void StsSensorBatch::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsSensorBatch::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("number", (Text_t*)&fNumber);
+  list->add("date",   FairDb::MakeDateTimeString(fDate).Data());
+  list->add("comment", (Text_t*)&fComment);
+}
+
+Bool_t StsSensorBatch::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+
+  Text_t number[MAX_TEXT_SIZE];
+  if (!list->fill("number", number, MAX_TEXT_SIZE))  {return kFALSE;}
+  fNumber = number;
+
+  Text_t date[MAX_TEXT_SIZE];
+  if (!list->fill("date", date, MAX_TEXT_SIZE)) {return kFALSE;}
+  fDate = FairDb::MakeTimeStamp(date);
+
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))     {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsSensorBatch::clear()
+{
+  fId = 0;
+  fNumber = "";
+  fDate = ValTimeStamp::GetBOT();
+  fComment = "";
+
+  delete fSensors;
+  fSensors = NULL;
+}
+
+
+void StsSensorBatch::Print()
+{
+  std::cout << "Sts Sensor Batch Instance:"                         << std::endl;
+  std::cout << "   Sensor Batch Id       = "     << fId             << std::endl;
+  std::cout << "   Batch Number          = "     << fNumber         << std::endl;
+  std::cout << "   Date                  = "     << fDate           << std::endl;
+  std::cout << "   Comment               = "     << fComment        << std::endl;
+  std::cout                                                         << std::endl;
+}
+
+StsSensorBatch* StsSensorBatch::GetBatchById(Int_t batchId, UInt_t runId)
+{
+  StsSensorBatch batch;
+  FairDbReader<StsSensorBatch> r_batch = *batch.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_batch.Activate(context, batch.GetVersion());
+  return (StsSensorBatch *)r_batch.GetRowByIndex(batchId);
+}
+
+TObjArray* StsSensorBatch::GetSensors()
+{
+  if (!fSensors)
+  {
+    fSensors = StsSensor::GetSensors(fId);
+  }
+
+  return fSensors;
+}
+
+string StsSensorBatch::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO           INT NOT NULL,";
+  sql += "  ROW_ID          INT NOT NULL,";
+  sql += "  ID              INT NOT NULL,";
+  sql += "  NUMBER          TEXT,";
+  sql += "  DATE            DATETIME,";
+  sql += "  COMMENT         TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsSensorBatch::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in  >> fId
+          >> fNumber
+          >> fDate
+          >> fComment;
+}
+
+void StsSensorBatch::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fNumber
+          << fDate
+          << fComment;
+}
+
+StsSensorBatch::StsSensorBatch(const StsSensorBatch& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fNumber = from.fNumber;
+  fDate = from.fDate;
+  fComment = from.fComment;
+}
+
+StsSensorBatch& StsSensorBatch::operator=(const StsSensorBatch& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fNumber = from.fNumber;
+  fDate = from.fDate;
+  fComment = from.fComment;
+
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsSensorBatch.h
+++ b/dbExamples/cbm_sts/src/StsSensorBatch.h
@@ -1,0 +1,79 @@
+#ifndef STSSENSORBATCH_H
+#define STSSENSORBATCH_H
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsSensorBatch : public FairDbGenericParSet<StsSensorBatch>
+{
+
+using TObject::Compare;
+
+  public :
+    StsSensorBatch(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsSensorBatch", 
+              const char* title = "Sts Batch Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsSensorBatch(void);
+    StsSensorBatch(const StsSensorBatch& from);
+    StsSensorBatch& operator=(const StsSensorBatch& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsSensorBatch* GetBatchById(Int_t batchId, UInt_t runId = 0);
+    TObjArray*             GetSensors();
+
+    Int_t        GetId()            const { return fId; }
+    string       GetNumber()        const { return fNumber; }
+    ValTimeStamp GetDate()          const { return fDate; }
+    string       GetComment()       const { return fComment; }
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetId(Int_t value)               { fId = value; }
+    void SetNumber(string value)          { fNumber = value; }
+    void SetDate(ValTimeStamp value)      { fDate = value; }
+    void SetComment(string value)         { fComment = value; }
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    TObjArray*        fSensors; //! Transient data member
+
+    Int_t             fId;
+    string            fNumber;
+    ValTimeStamp      fDate;
+    string            fComment;
+
+    ClassDef(StsSensorBatch,1); // ROOT class definition
+};
+
+#endif /* !STSSENSORBATCH_H*/
+

--- a/dbExamples/cbm_sts/src/StsSensorLocation.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorLocation.cxx
@@ -1,0 +1,179 @@
+#include "StsSensorLocation.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsSensorLocation);
+
+static FairDbGenericParRegistry<StsSensorLocation> sts("StsSensorLocation", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsSensorLocation>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsSensorLocation>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsSensorLocation>;
+
+StsSensorLocation::StsSensorLocation(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsSensorLocation>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fLocation(""),
+  fOwner(""),
+  fComment("")
+{
+
+}
+
+StsSensorLocation::~StsSensorLocation()
+{
+
+}
+
+void StsSensorLocation::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsSensorLocation::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("location", (Text_t*)&fLocation);
+  list->add("owner", (Text_t*)&fOwner);
+  list->add("comment", (Text_t*)&fComment);
+}
+
+Bool_t StsSensorLocation::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+
+  Text_t location[MAX_TEXT_SIZE];
+  if (!list->fill("location", location, MAX_TEXT_SIZE)) {return kFALSE;}
+  fLocation = location;
+
+  Text_t owner[MAX_TEXT_SIZE];
+  if (!list->fill("owner", owner, MAX_TEXT_SIZE)) {return kFALSE;}
+  fOwner = owner;
+
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))     {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsSensorLocation::clear()
+{
+  fId = 0;
+  fLocation = "";
+  fOwner = "";
+  fComment = "";
+}
+
+
+void StsSensorLocation::Print()
+{
+  std::cout << "Sts Sensor Location Instance:"                        << std::endl;
+  std::cout << "   Sensor Location Id       = "     << fId            << std::endl;
+  std::cout << "   Location                 = "     << fLocation      << std::endl;
+  std::cout << "   Owner                    = "     << fOwner         << std::endl;
+  std::cout << "   Comment                  = "     << fComment       << std::endl;
+  std::cout                                                           << std::endl;
+}
+
+StsSensorLocation* StsSensorLocation::GetLocationById(Int_t locationId, UInt_t runId)
+{
+  StsSensorLocation location;
+  FairDbReader<StsSensorLocation> r_location = *location.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_location.Activate(context, location.GetVersion());
+  return (StsSensorLocation *)r_location.GetRowByIndex(locationId);
+}
+
+string StsSensorLocation::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO           INT NOT NULL,";
+  sql += "  ROW_ID          INT NOT NULL,";
+  sql += "  ID              INT NOT NULL,";
+  sql += "  LOCATION        TEXT,";
+  sql += "  OWNER           TEXT,";
+  sql += "  COMMENT         TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsSensorLocation::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fLocation
+         >> fOwner
+         >> fComment;
+}
+
+void StsSensorLocation::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fLocation
+          << fOwner
+          << fComment;
+}
+
+StsSensorLocation::StsSensorLocation(const StsSensorLocation& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fLocation = from.fLocation;
+  fOwner = from.fOwner;
+  fComment = from.fComment;
+}
+
+StsSensorLocation& StsSensorLocation::operator=(const StsSensorLocation& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fLocation = from.fLocation;
+  fOwner = from.fOwner;
+  fComment = from.fComment;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsSensorLocation.h
+++ b/dbExamples/cbm_sts/src/StsSensorLocation.h
@@ -1,0 +1,76 @@
+#ifndef STSSENSORLOCATION_H
+#define STSSENSORLOCATION_H
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsSensorLocation : public FairDbGenericParSet<StsSensorLocation>
+{
+
+using TObject::Compare;
+
+  public :
+    StsSensorLocation(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsSensorLocation", 
+              const char* title = "Sts Sensor Location Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsSensorLocation(void);
+    StsSensorLocation(const StsSensorLocation& from);
+    StsSensorLocation& operator=(const StsSensorLocation& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsSensorLocation* GetLocationById(Int_t locationId, UInt_t runId = 0);
+
+    Int_t    GetId()              const { return fId; }
+    string   GetLocation()        const { return fLocation; }
+    string   GetOwner()           const { return fOwner; }
+    string   GetComment()         const { return fComment; }
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetId(Int_t value)               { fId = value; }
+    void SetLocation(string value)        { fLocation = value; }
+    void SetOwner(string value)           { fOwner = value; }
+    void SetComment(string value)         { fComment = value; }
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    Int_t    fId;
+    string   fLocation;
+    string   fOwner;
+    string   fComment;
+
+    ClassDef(StsSensorLocation,1); // ROOT class definition
+};
+
+#endif /* !STSSENSORLOCATION_H*/
+

--- a/dbExamples/cbm_sts/src/StsSensorType.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorType.cxx
@@ -1,0 +1,269 @@
+#include "StsSensorType.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsSensorType);
+
+static FairDbGenericParRegistry<StsSensorType> sts("StsSensorType", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsSensorType>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsSensorType>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsSensorType>;
+
+StsSensorType::StsSensorType(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsSensorType>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fTypeName(""),
+  fProcessing(""),
+  fWidth(0.),
+  fHeight(0.),
+  fAliMarkWidth(0.),
+  fAliMarkHeight(0.),
+  fStripsPerSide(0),
+  fPitch(0.),
+  fThickness(0.),
+  fStereoAngleP(0.),
+  fStereoAngleN(0.),
+  fComment("")
+{
+
+}
+
+StsSensorType::~StsSensorType()
+{
+
+}
+
+void StsSensorType::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsSensorType::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("type_name", (Text_t*)&fTypeName);
+  list->add("processing", (Text_t*)&fProcessing);
+  list->add("widht", fWidth);
+  list->add("height", fHeight);
+  list->add("alimark_widht", fAliMarkWidth);
+  list->add("alimark_height", fAliMarkHeight);
+  list->add("strips_per_side", fStripsPerSide);
+  list->add("pitch", fPitch);
+  list->add("thickness", fThickness);
+  list->add("stereo_angle_p", fStereoAngleP);
+  list->add("stereo_angle_n", fStereoAngleN);
+  list->add("comment", (Text_t*)&fComment);
+}
+
+Bool_t StsSensorType::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+
+  Text_t name[MAX_TEXT_SIZE];
+  if (!list->fill("type_name", name, MAX_TEXT_SIZE))  {return kFALSE;}
+  fTypeName = name;
+
+  Text_t processing[MAX_TEXT_SIZE];
+  if (!list->fill("processing", processing, MAX_TEXT_SIZE)) {return kFALSE;}
+  fProcessing = processing;
+
+  if (!list->fill("width", &fWidth)) {return kFALSE;}
+  if (!list->fill("height", &fHeight)) {return kFALSE;}
+  if (!list->fill("alimark_widht", &fAliMarkWidth)) {return kFALSE;}
+  if (!list->fill("alimark_height", &fAliMarkHeight)) {return kFALSE;}
+  if (!list->fill("strips_per_side", &fStripsPerSide)) {return kFALSE;}
+  if (!list->fill("pitch", &fPitch)) {return kFALSE;}
+  if (!list->fill("thickness", &fThickness)) {return kFALSE;}
+  if (!list->fill("stereo_angle_p", &fStereoAngleP)) {return kFALSE;}
+  if (!list->fill("stereo_angle_n", &fStereoAngleN)) {return kFALSE;}
+
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))     {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsSensorType::clear()
+{
+  fId = 0;
+  fTypeName = "";
+  fProcessing = "";
+  fWidth = 0.;
+  fHeight = 0.;
+  fAliMarkWidth = 0.;
+  fAliMarkHeight = 0.;
+  fStripsPerSide = 0;
+  fPitch = 0.;
+  fThickness = 0.;
+  fStereoAngleP = 0.;
+  fStereoAngleN = 0.;
+  fComment = "";
+}
+
+StsSensorType* StsSensorType::GetTypeById(Int_t typeId, UInt_t runId)
+{
+  StsSensorType type;
+  FairDbReader<StsSensorType> r_type = *type.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_type.Activate(context, type.GetVersion());
+  return (StsSensorType *)r_type.GetRowByIndex(typeId);
+}
+
+void StsSensorType::Print()
+{
+  std::cout << "Sts Sensor Type Instance:"                          << std::endl;
+  std::cout << "   Sensor Type Id         = "     << fId            << std::endl;
+  std::cout << "   Type Name              = "     << fTypeName      << std::endl;
+  std::cout << "   Processing             = "     << fProcessing    << std::endl;
+  std::cout << "   Widht                  = "     << fWidth         << std::endl;
+  std::cout << "   Height                 = "     << fHeight        << std::endl;
+  std::cout << "   Alignment Mark Width   = "     << fAliMarkWidth  << std::endl;
+  std::cout << "   Alignment Mark Height  = "     << fAliMarkHeight << std::endl;
+  std::cout << "   Strips per side        = "     << fStripsPerSide << std::endl;
+  std::cout << "   Pitch                  = "     << fPitch         << std::endl;
+  std::cout << "   Thickness              = "     << fThickness     << std::endl;
+  std::cout << "   Stereo angle P         = "     << fStereoAngleP  << std::endl;
+  std::cout << "   Stereo angle N         = "     << fStereoAngleN  << std::endl;
+  std::cout << "   Comment                = "     << fComment       << std::endl;
+  std::cout                                                         << std::endl;
+}
+
+string StsSensorType::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO           INT NOT NULL,";
+  sql += "  ROW_ID          INT NOT NULL,";
+  sql += "  ID              INT NOT NULL,";
+  sql += "  TYPE_NAME       TEXT,";
+  sql += "  PROCESSING      TEXT,";
+  sql += "  WIDTH           DOUBLE,";
+  sql += "  HEIGHT          DOUBLE,";
+  sql += "  ALIMARK_WIDTH   DOUBLE,";
+  sql += "  ALIMARK_HEIGHT  DOUBLE,";
+  sql += "  STRIPS_PER_SIDE INT,";
+  sql += "  PITCH           DOUBLE,";
+  sql += "  THICKNESS       DOUBLE,";
+  sql += "  STEREO_ANGLE_P  DOUBLE,";
+  sql += "  STEREO_ANGLE_N  DOUBLE,";
+  sql += "  COMMENT         TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsSensorType::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fTypeName
+         >> fProcessing
+         >> fWidth
+         >> fHeight
+         >> fAliMarkWidth
+         >> fAliMarkHeight
+         >> fStripsPerSide
+         >> fPitch
+         >> fThickness
+         >> fStereoAngleP
+         >> fStereoAngleN
+         >> fComment;
+}
+
+void StsSensorType::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fTypeName
+          << fProcessing
+          << fWidth
+          << fHeight
+          << fAliMarkWidth
+          << fAliMarkHeight
+          << fStripsPerSide
+          << fPitch
+          << fThickness
+          << fStereoAngleP
+          << fStereoAngleN
+          << fComment;
+}
+
+StsSensorType::StsSensorType(const StsSensorType& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fTypeName = from.fTypeName;
+  fProcessing = from.fProcessing;
+  fWidth = from.fWidth;
+  fHeight = from.fHeight;
+  fAliMarkWidth = from.fAliMarkWidth;
+  fAliMarkHeight = from.fAliMarkHeight;
+  fStripsPerSide = from.fStripsPerSide;
+  fPitch = from.fPitch;
+  fThickness = from.fThickness;
+  fStereoAngleP = from.fStereoAngleP;
+  fStereoAngleN = from.fStereoAngleN;
+  fComment = from.fComment;
+}
+
+StsSensorType& StsSensorType::operator=(const StsSensorType& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fTypeName = from.fTypeName;
+  fProcessing = from.fProcessing;
+  fWidth = from.fWidth;
+  fHeight = from.fHeight;
+  fAliMarkWidth = from.fAliMarkWidth;
+  fAliMarkHeight = from.fAliMarkHeight;
+  fStripsPerSide = from.fStripsPerSide;
+  fPitch = from.fPitch;
+  fThickness = from.fThickness;
+  fStereoAngleP = from.fStereoAngleP;
+  fStereoAngleN = from.fStereoAngleN;
+  fComment = from.fComment;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsSensorType.h
+++ b/dbExamples/cbm_sts/src/StsSensorType.h
@@ -1,0 +1,107 @@
+#ifndef STSSENSORTYPE_H
+#define STSSENSORTYPE_H
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsSensorType : public FairDbGenericParSet<StsSensorType>
+{
+
+using TObject::Compare;
+
+  public :
+    StsSensorType(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsSensorType", 
+              const char* title = "Sts Sensor Type Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsSensorType(void);
+    StsSensorType(const StsSensorType& from);
+    StsSensorType& operator=(const StsSensorType& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsSensorType* GetTypeById(Int_t typeId, UInt_t runId = 0);
+
+    Int_t    GetId()            const { return fId; }
+    string   GetTypeName()      const { return fTypeName; }
+    string   GetProcessing()    const { return fProcessing; }
+    Double_t GetWidth()         const { return fWidth; }
+    Double_t GetHeight()        const { return fHeight; }
+    Double_t GetAliMarkWidth()  const { return fAliMarkWidth; }
+    Double_t GetAliMarkHeight() const { return fAliMarkHeight; }
+    Int_t    GetStripsPerSide() const { return fStripsPerSide; }
+    Double_t GetPitch()         const { return fPitch; }
+    Double_t GetThickness()     const { return fThickness; }
+    Double_t GetStereoAngleP()  const { return fStereoAngleP; }
+    Double_t GetStereoAngleN()  const { return fStereoAngleN; }
+    string   GetComment()       const { return fComment; }
+
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetId(Int_t value)               { fId = value; }
+    void SetTypeName(string value)        { fTypeName = value; }
+    void SetProcessing(string value)      { fProcessing = value; }
+    void SetWidth(Double_t value)         { fWidth = value; }
+    void SetHeight(Double_t value)        { fHeight = value; }
+    void SetAliMarkWidth(Double_t value)  { fAliMarkWidth = value; }
+    void SetAliMarkHeight(Double_t value) { fAliMarkHeight = value; }
+    void SetStripsPerSide(Int_t value)    { fStripsPerSide = value; }
+    void SetPitch(Double_t value)            { fPitch = value; }
+    void SetThickness(Double_t value)     { fThickness = value; }
+    void SetStereoAngleP(Double_t value)  { fStereoAngleP = value; }
+    void SetStereoAngleN(Double_t value)  { fStereoAngleN = value; }
+    void SetComment(string value)         { fComment = value; }
+
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    TObjArray* fOpticalInspections;
+
+    Int_t    fId;
+    string   fTypeName;
+    string   fProcessing;
+    Double_t fWidth;
+    Double_t fHeight;
+    Double_t fAliMarkWidth;
+    Double_t fAliMarkHeight;
+    Int_t    fStripsPerSide;
+    Double_t    fPitch;
+    Double_t fThickness;
+    Double_t fStereoAngleP;
+    Double_t fStereoAngleN;
+    string   fComment;
+
+    ClassDef(StsSensorType,1); // ROOT class definition
+};
+
+#endif /* !STSSENSORTYPE_H*/
+

--- a/dbExamples/cbm_sts/src/StsSensorVendor.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorVendor.cxx
@@ -1,0 +1,220 @@
+#include "StsSensorVendor.h"
+
+#include "FairDbLogFormat.h"
+#include "FairDbLogService.h"
+#include "FairDbOutTableBuffer.h"         // for FairDbOutRowStream
+#include "FairDbStatement.h"              // for FairDbStatement
+#include "FairParamList.h"                // for FairParamList
+#include "FairDbParFactory.h"
+
+#include "Riosfwd.h"                     // for ostream
+#include "TString.h"                     // for TString
+
+#include <stdlib.h>                      // for exit
+#include <memory>                        // for auto_ptr, etc
+#include <vector>                        // for vector, vector<>::iterator
+
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/progress.hpp>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+
+
+using namespace std;
+using namespace boost;
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+
+
+#define MAX_TEXT_SIZE 255
+
+ClassImp(StsSensorVendor);
+
+static FairDbGenericParRegistry<StsSensorVendor> sts("StsSensorVendor", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class  FairDbGenericParSet<StsSensorVendor>;
+
+#include "FairDbReader.tpl"
+template class  FairDbReader<StsSensorVendor>;
+
+#include "FairDbWriter.tpl"
+template class  FairDbWriter<StsSensorVendor>;
+
+StsSensorVendor::StsSensorVendor(FairDbDetector::Detector_t detid, 
+              DataType::DataType_t dataid, 
+              const char* name, 
+              const char* title, 
+              const char* context, 
+              Bool_t ownership):
+  FairDbGenericParSet<StsSensorVendor>(detid, dataid, name, title, context, ownership),
+  fId(0),
+  fVendorName(""),
+  fLocation(""),
+  fContactInfo(""),
+  fComment("")
+{
+
+}
+
+StsSensorVendor::~StsSensorVendor()
+{
+
+}
+
+void StsSensorVendor::putParams(FairParamList* list)
+{
+  std::cout<<"-I- StsSensorVendor::putParams() called"<<std::endl;
+  if(!list) { return; }
+  list->add("id", fId);
+  list->add("vendor_name", (Text_t*)&fVendorName);
+  list->add("location", (Text_t*)&fLocation);
+  list->add("contact_info", (Text_t*)&fContactInfo);
+  list->add("comment", (Text_t*)&fComment);
+}
+
+Bool_t StsSensorVendor::getParams(FairParamList* list)
+{
+  if (!list) { return kFALSE;}
+
+  if (!list->fill("id", &fId))  {return kFALSE;}
+
+  Text_t vendor_name[MAX_TEXT_SIZE];
+  if (!list->fill("vendor_name", vendor_name, MAX_TEXT_SIZE))  {return kFALSE;}
+  fVendorName = vendor_name;
+
+  Text_t location[MAX_TEXT_SIZE];
+  if (!list->fill("location", location, MAX_TEXT_SIZE)) {return kFALSE;}
+  fLocation = location;
+
+  Text_t contact_info[MAX_TEXT_SIZE];
+  if (!list->fill("contact_info", contact_info, MAX_TEXT_SIZE)) {return kFALSE;}
+  fContactInfo = contact_info;
+
+  Text_t comment[MAX_TEXT_SIZE];
+  if (!list->fill("comment", comment, MAX_TEXT_SIZE))     {return kFALSE;}
+  fComment = comment;
+
+  return kTRUE;
+}
+
+void StsSensorVendor::clear()
+{
+  fId = 0;
+  fVendorName = "";
+  fLocation = "";
+  fContactInfo = "";
+  fComment = "";
+}
+
+
+void StsSensorVendor::Print()
+{
+  std::cout << "Sts Sensor Vendor Instance:"                          << std::endl;
+  std::cout << "   Sensor Vendor Id       = "     << fId            << std::endl;
+  std::cout << "   Vendor Name            = "     << fVendorName    << std::endl;
+  std::cout << "   Location               = "     << fLocation      << std::endl;
+  std::cout << "   Contact info           = "     << fContactInfo   << std::endl;
+  std::cout << "   Comment                = "     << fComment       << std::endl;
+  std::cout                                                         << std::endl;
+}
+
+StsSensorVendor* StsSensorVendor::GetVendorById(Int_t vendorId, UInt_t runId)
+{
+  StsSensorVendor vendor;
+  FairDbReader<StsSensorVendor> r_vendor = *vendor.GetParamReader();
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_vendor.Activate(context, vendor.GetVersion());
+  return (StsSensorVendor *)r_vendor.GetRowByIndex(vendorId);
+}
+
+StsSensorVendor* StsSensorVendor::GetVendorByName(string vendorName, UInt_t runId)
+{
+  StsSensorVendor vendor;
+  FairDbReader<StsSensorVendor> r_vendor;
+
+  ValTimeStamp ts;
+  if (runId)
+    ts = ValTimeStamp(runId);
+  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
+
+  r_vendor.Activate(context, vendor.GetVersion());
+  Int_t numRows = r_vendor.GetNumRows();
+  if (!numRows)
+    return NULL;
+
+  for (Int_t i=0; i < numRows; i++)
+  {
+    StsSensorVendor *vend = (StsSensorVendor*)r_vendor.GetRow(i);
+    if (!vend)
+      continue;
+
+    if (vend->GetVendorName() == vendorName)
+      return vend;
+  }
+
+  return NULL;
+}
+
+string StsSensorVendor::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO           INT NOT NULL,";
+  sql += "  ROW_ID          INT NOT NULL,";
+  sql += "  ID              INT NOT NULL,";
+  sql += "  VENDOR_NAME     TEXT,";
+  sql += "  LOCATION        TEXT,";
+  sql += "  CONTACT_INFO    TEXT,";
+  sql += "  COMMENT         TEXT,";
+  sql += "  primary key(SEQNO,ROW_ID,ID))";
+  return sql;
+}
+
+void StsSensorVendor::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId
+         >> fVendorName
+         >> fLocation
+         >> fContactInfo
+         >> fComment;
+}
+
+void StsSensorVendor::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId
+          << fVendorName
+          << fLocation
+          << fContactInfo
+          << fComment;
+}
+
+StsSensorVendor::StsSensorVendor(const StsSensorVendor& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fVendorName = from.fVendorName;
+  fLocation = from.fLocation;
+  fContactInfo = from.fContactInfo;
+  fComment = from.fComment;
+}
+
+StsSensorVendor& StsSensorVendor::operator=(const StsSensorVendor& from){
+  fCompId = from.GetCompId();
+  fId = from.fId;
+  fVendorName = from.fVendorName;
+  fLocation = from.fLocation;
+  fContactInfo = from.fContactInfo;
+  fComment = from.fComment;
+  
+  return *this;
+}

--- a/dbExamples/cbm_sts/src/StsSensorVendor.h
+++ b/dbExamples/cbm_sts/src/StsSensorVendor.h
@@ -1,0 +1,80 @@
+#ifndef STSSENSORVENDOR_H
+#define STSSENSORVENDOR_H
+
+#include "DataType.h"         
+#include "FairDbGenericParSet.h"
+
+#include "TObjArray.h"
+#include "TGeoMaterial.h" 
+#include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
+
+#include <iostream>                     // for operator<<, basic_ostream, etc
+#include <string>                       // for string
+
+using namespace std;
+
+class StsSensorVendor : public FairDbGenericParSet<StsSensorVendor>
+{
+
+using TObject::Compare;
+
+  public :
+    StsSensorVendor(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
+              DataType::DataType_t dataid = DataType::kData, 
+              const char* name = "StsSensorVendor", 
+              const char* title = "Sts Sensor Vendor Static Data", 
+              const char* context = "StsDefaultContext", 
+              Bool_t ownership=kTRUE);
+
+    virtual ~StsSensorVendor(void);
+    StsSensorVendor(const StsSensorVendor& from);
+    StsSensorVendor& operator=(const StsSensorVendor& from);
+
+    // RuntimeDB interfaces 
+    void   clear(void);
+    void   putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
+
+    // Dump Object
+    void   Print();
+
+    /// Getter Functions
+    static StsSensorVendor* GetVendorById(Int_t vendorId, UInt_t runId = 0);
+    static StsSensorVendor* GetVendorByName(string vendorName, UInt_t runId = 0);
+
+    Int_t    GetId()              const { return fId; }
+    string   GetVendorName()      const { return fVendorName; }
+    string   GetLocation()        const { return fLocation; }
+    string   GetContactInfo()     const { return fContactInfo; }
+    string   GetComment()         const { return fComment; }
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+
+    /// Setter Functions
+    void SetId(Int_t value)               { fId = value; }
+    void SetVendorName(string value)      { fVendorName = value; }
+    void SetLocation(string value)        { fLocation = value; }
+    void SetContactInfo(string value)     { fContactInfo = value; }
+    void SetComment(string value)         { fComment = value; }
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+  private:
+    Int_t    fId;
+    string   fVendorName;
+    string   fLocation;
+    string   fContactInfo;
+    string   fComment;
+
+    ClassDef(StsSensorVendor,1); // ROOT class definition
+};
+
+#endif /* !STSSENSORVENDOR_H*/
+


### PR DESCRIPTION
Dear Denis, I have implemented the db schema I showed previously to you. (see file attached)

The idea behind was, that the user becomes a full relational model, where you can query other entities from within single given.
For example `StsSensor` has many `StsOpticalInspection` so you could make following calls:
```
  StsSensorBatch *batch = StsSensorBatch::GetBatchById(0);
  StsSensor *sensor = batch->GetSensors()->At(0);
  StsOpticalInspection *inspection = sensor->GetOpticalInspections()->At(0);

  StsSensor *other = inspection->GetSensor();
```
or even
```
  StsSensorBatch *batch = StsDefect::GetDefectById(0)->GetImage()->GetInspection()->GetSensor()->GetBatch();
  batch->Print();
```

This template is implemented across all the classes in the pull request.
There is a macro `sensor_test.C` in the corresponding directory to prime the DB and test relations.
I have reimplemented several existing classes in order not to interfere with your code.

However, I think I have misunderstood the concept of aggregation in the FairDb.
Could you please check the sanity of my design and correctness of implementation. I would like to have your feedback before I start to work on the export scripts of my data to the DB.

Cheers,
E.

![db_schema](https://cloud.githubusercontent.com/assets/661749/24805676/dfa4d698-1bb2-11e7-9329-5a628d2fd68f.png)