### PR TITLE
Add static array read and write methods to FairDbGenericParSet

### DIFF
--- a/dbInterface/FairDbGenericParSet.h
+++ b/dbInterface/FairDbGenericParSet.h
@@ -60,7 +60,9 @@ class FairDbGenericParSet : public FairDbParSet
     // RuntimeDb IO 
     virtual void clear();
     virtual void fill(UInt_t rid=0);
+    static TObjArray* FillArray(Int_t compId=-1, UInt_t rid=0);
     virtual void store(UInt_t rid=0);
+    static void StoreArray(TObjArray *array, Int_t compId=-1, UInt_t rid=0);
 
     // Standard Validity frame definition
     virtual ValCondition GetContext(UInt_t rid) {


### PR DESCRIPTION
Hi, I propose here an addition of 2 static methods to the `FairDbGenericParSet`'s functionality.
It will allow to store arrays of inheriting objects individually by default or grouped by common composite id.
Example:
```
// store individually
FairDbTutPar::StoreArray(array);

// store grouped
FairDbTutPar::StoreArray(array, compid, rid);
```

And to read them back:
```
// read all valid data
TObjArray *array = FairDbTutPar::FillArray();
// read grouped
TObjArray *array = FairDbTutPar::FillArray(compid, rid);
```
To group the records when reading I analyse the composite id of the validity record. Since the inheriting object not always have a field for it.