### PR TITLE
Add support for streaming null objects

### DIFF
--- a/dbInterface/FairDb.cxx
+++ b/dbInterface/FairDb.cxx
@@ -276,6 +276,12 @@ TString FairDb::StreamAsString(const Double_t* arr, Int_t size)
 
 TString FairDb::StreamAsString(const TObject* obj, Int_t& size)
 {
+  if (!obj)
+  {
+    size = 0;
+    return "";
+  }
+
   // ROOT IO is used to create a packed
   // hexadecimal string out of the object
 

--- a/dbInterface/FairDbStreamer.cxx
+++ b/dbInterface/FairDbStreamer.cxx
@@ -276,6 +276,9 @@ void FairDbStreamer::Fill(Double_t* arr)
 
 void FairDbStreamer::Fill(TObject* obj)
 {
+  if (!obj || fString.IsNull())
+    return;
+
   // <DB> changed according to Jorg Förtsch
   //      date 28.03.2017
   // Decryption str


### PR DESCRIPTION
Problem statement: there is no need to store the serialised "empty" root objects in the DB, because it occupies space. For example an empty TH1F histogram will take 1040 bytes to be stored.

My user story: general optical inspection and sensor warp inspections (stored as a TGraph2D in DB) are not performed simultaneously, but they share the same table. 
So first I update the table with the results from general inspection and store NULL in for the warp results. Then I perform the sensor warp scan, fill TGraph2D and update the record (or insert a new one with more recent IoV), at this step the serialised object is put in the table.

This PR updates `FairDb::StreamAsString(const TObject* obj, Int_t& size)` serialiser to account for NULL objects (in this case an empty string is stored in the table column) and `FairDbStreamer::Fill(TObject* obj)` deserialiser to not crash on empty strings from tables or NULL objects.

As an example, In this case storing methods are not changed:
```
void FairDbTutPar::Store(FairDbOutTableBuffer& res_out,
                         const FairDbValRecord* valrec) const
{
  FairDbStreamer histStreamer(fHist);
  res_out << fTopPitch  << fTopAnchor   << fTopNrFE  << fFeType << histStreamer;
}
```
And filling methods are changed like this:
```
void FairDbTutPar::Fill(FairDbResultPool& res_in,
                        const FairDbValRecord* valrec)
{
  FairDbStreamer histStreamer(fHist);
  res_in >> fTopPitch  >> fTopAnchor   >> fTopNrFE  >> fFeType >> histStreamer;
  if (!histStreamer.AsString().IsNull())
  {
    if (!fHist) fHist = new TH1F();
    histStreamer.Fill(fHist);
  }
}
```