### PR TITLE
StsDefect: Fix method name collision

### DIFF
--- a/dbExamples/cbm_sts/macros/sensor_test.C
+++ b/dbExamples/cbm_sts/macros/sensor_test.C
@@ -397,9 +397,9 @@ void test_relations()
   image->Print();
   StsDefect *defect = image->GetDefects()->At(0);
   defect->Print();
-  StsDefectType *defectType = defect->GetType();
+  StsDefectType *defectType = defect->GetDefectType();
   defectType->Print();
-  StsDefectContext *defectContext = defect->GetContext();
+  StsDefectContext *defectContext = defect->GetDefectContext();
   defectContext->Print();
 }
 
@@ -407,7 +407,7 @@ void test_backward_relations()
 {
   StsDefect *defect = StsDefect::GetDefectById(0);
   defect->Print();
-  StsInspectionImage *image = defect->GetImage();
+  StsInspectionImage *image = defect->GetDefectImage();
   image->Print();
   StsOpticalInspection *inspection = defect->GetInspection();
   inspection->Print();

--- a/dbExamples/cbm_sts/src/StsDefect.h
+++ b/dbExamples/cbm_sts/src/StsDefect.h
@@ -54,17 +54,17 @@ using TObject::Compare;
       return fInspection;
     }
 
-    StsDefectType* GetType() {
+    StsDefectType* GetDefectType() {
       if (!fType) fType = StsDefectType::GetDefectTypeById(fTypeId);
       return fType;
     }
 
-    StsDefectContext* GetContext() {
+    StsDefectContext* GetDefectContext() {
       if (!fContext) fContext = StsDefectContext::GetDefectContextById(fContextId);
       return fContext;
     }
 
-    StsInspectionImage* GetImage() {
+    StsInspectionImage* GetDefectImage() {
       if (!fImage) fImage = StsInspectionImage::GetInspectionImageById(fImageId);
       return fImage;
     }


### PR DESCRIPTION
Fixes method GetContext() name collision by its renaming.