### PR TITLE
FairDbGenericParSet: Add more static getters

### DIFF
--- a/dbExamples/cbm_sts/macros/sensor_test.C
+++ b/dbExamples/cbm_sts/macros/sensor_test.C
@@ -99,6 +99,7 @@ void prime_defect()
     defect.SetLogTitle(logTitle);
     defect.SetCompId(0);
     defect.SetId(i);
+    defect.SetLeft(i);
 
     w_defect << defect;
   }
@@ -299,7 +300,7 @@ void prime_sensor()
 
 void sensor_read(Int_t sensorId = 0, UInt_t runId = 0)
 {
-  StsSensor* sensor = StsSensor::GetSensorById(sensorId, runId);
+  StsSensor* sensor = StsSensor::GetById(sensorId, runId);
   print_sensor(sensor);
 }
 
@@ -366,7 +367,7 @@ void prime_inspection_image()
 
 void inspection_read(int id = 0, UInt_t runId = 0)
 {
-  StsOpticalInspection* inspection = StsOpticalInspection::GetInspectionById(id, runId);
+  StsOpticalInspection* inspection = StsOpticalInspection::GetById(id, runId);
   if (!inspection)
     return;
   inspection->Print();
@@ -381,7 +382,7 @@ void inspection_read(int id = 0, UInt_t runId = 0)
 
 void test_relations()
 {
-  StsSensorBatch *batch = StsSensorBatch::GetBatchById(0);
+  StsSensorBatch *batch = StsSensorBatch::GetById(0);
   batch->Print();
   StsSensor *sensor = batch->GetSensors()->At(0);
   sensor->Print();
@@ -405,7 +406,7 @@ void test_relations()
 
 void test_backward_relations()
 {
-  StsDefect *defect = StsDefect::GetDefectById(0);
+  StsDefect *defect = StsDefect::GetById(0);
   defect->Print();
   StsInspectionImage *image = defect->GetDefectImage();
   image->Print();

--- a/dbExamples/cbm_sts/src/StsDefect.cxx
+++ b/dbExamples/cbm_sts/src/StsDefect.cxx
@@ -204,78 +204,30 @@ void StsDefect::Print()
   std::cout                                                                    << std::endl;
 }
 
-StsDefect* StsDefect::GetDefectById(Int_t defectId, UInt_t runId)
-{
-  StsDefect defect;
-  FairDbReader<StsDefect> r_defect = *defect.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_defect.Activate(context, defect.GetVersion());
-  return (StsDefect *)r_defect.GetRowByIndex(defectId);
-}
-
 TObjArray* StsDefect::GetDefectsByImageId(Int_t inspectionImageId, UInt_t runId)
 {
-  StsDefect defect;
-  FairDbReader<StsDefect> r_defect;
+  StsInspectionImage *image = StsInspectionImage::GetById(inspectionImageId, runId);
+  TObjArray *defects = StsDefect::GetDefectsByInspectionId(image->GetInspectionId(), runId);
+  Int_t numRows = defects->GetEntries();
 
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_defect.Activate(context, defect.GetVersion());
-  Int_t numRows = r_defect.GetNumRows();
-  if (!numRows)
-    return NULL;
-
-  TObjArray* defects = new TObjArray(numRows);
+  TObjArray *result = new TObjArray(numRows);
   for (Int_t i=0; i < numRows; i++)
   {
-    StsDefect *def = (StsDefect*)r_defect.GetRow(i);
+    StsDefect *def = (StsDefect*)defects->At(i);
     if (!def)
       continue;
 
     if (def->GetImageId() == inspectionImageId) {
-      defects->Add(def);
+      result->Add(def);
     }
   }
 
-  return defects;
-}
-
-TObjArray* StsDefect::GetDefectsByInspectionId(Int_t inspectionId, UInt_t runId)
-{
-  StsDefect defect;
-  FairDbReader<StsDefect> r_defect;
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_defect.Activate(context, defect.GetVersion());
-  Int_t numRows = r_defect.GetNumRows();
-  if (!numRows)
+  if (result->GetEntries()){
+    return result;
+  } else {
+    delete result;
     return NULL;
-
-  TObjArray* defects = new TObjArray(numRows);
-  for (Int_t i=0; i < numRows; i++)
-  {
-    StsDefect *def = (StsDefect*)r_defect.GetRow(i);
-    if (!def)
-      continue;
-
-    if (def->GetInspectionId() == inspectionId)
-      defects->Add(def);
   }
-
-  return defects;
 }
 
 string StsDefect::GetTableDefinition(const char* Name)

--- a/dbExamples/cbm_sts/src/StsDefect.h
+++ b/dbExamples/cbm_sts/src/StsDefect.h
@@ -27,7 +27,7 @@ using TObject::Compare;
     StsDefect(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
               DataType::DataType_t dataid = DataType::kData, 
               const char* name = "StsDefect", 
-              const char* title = "Sts Defect Type Static Data", 
+              const char* title = "Sts Defect Entity",
               const char* context = "StsDefaultContext", 
               Bool_t ownership=kTRUE);
 
@@ -44,28 +44,28 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsDefect* GetDefectById(Int_t defectId, UInt_t runId = 0);
     static TObjArray* GetDefectsByImageId(Int_t inspectionImageId, UInt_t runId = 0);
-    static TObjArray* GetDefectsByInspectionId(Int_t inspection, UInt_t runId = 0);
-
+    static TObjArray* GetDefectsByInspectionId(Int_t inspectionId, UInt_t runId = 0) {
+          return StsDefect::GetArray(inspectionId, runId);
+    }
 
     StsOpticalInspection* GetInspection() {
-      if (!fInspection) fInspection = StsOpticalInspection::GetInspectionById(fInspectionId);
+      if (!fInspection) fInspection = StsOpticalInspection::GetById(fInspectionId);
       return fInspection;
     }
 
     StsDefectType* GetDefectType() {
-      if (!fType) fType = StsDefectType::GetDefectTypeById(fTypeId);
+      if (!fType) fType = StsDefectType::GetById(fTypeId);
       return fType;
     }
 
     StsDefectContext* GetDefectContext() {
-      if (!fContext) fContext = StsDefectContext::GetDefectContextById(fContextId);
+      if (!fContext) fContext = StsDefectContext::GetById(fContextId);
       return fContext;
     }
 
     StsInspectionImage* GetDefectImage() {
-      if (!fImage) fImage = StsInspectionImage::GetInspectionImageById(fImageId);
+      if (!fImage) fImage = StsInspectionImage::GetById(fImageId);
       return fImage;
     }
 

--- a/dbExamples/cbm_sts/src/StsDefectContext.cxx
+++ b/dbExamples/cbm_sts/src/StsDefectContext.cxx
@@ -102,21 +102,6 @@ void StsDefectContext::Print()
   std::cout                                                         << std::endl;
 }
 
-StsDefectContext* StsDefectContext::GetDefectContextById(Int_t contextId, UInt_t runId)
-{
-  StsDefectContext defcontext;
-  FairDbReader<StsDefectContext> r_defcontext = *defcontext.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_defcontext.Activate(context, defcontext.GetVersion());
-  return (StsDefectContext *)r_defcontext.GetRowByIndex(contextId);
-}
-
 string StsDefectContext::GetTableDefinition(const char* Name)
 {
   string sql("create table ");

--- a/dbExamples/cbm_sts/src/StsDefectContext.h
+++ b/dbExamples/cbm_sts/src/StsDefectContext.h
@@ -39,8 +39,6 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsDefectContext* GetDefectContextById(Int_t defectId, UInt_t runId = 0);
-
     Int_t    GetId()              const { return fId; }
     string   GetContextName()     const { return fContextName; }
     Double_t GetWeight()          const { return fWeight; }

--- a/dbExamples/cbm_sts/src/StsDefectType.cxx
+++ b/dbExamples/cbm_sts/src/StsDefectType.cxx
@@ -102,21 +102,6 @@ void StsDefectType::Print()
   std::cout                                                         << std::endl;
 }
 
-StsDefectType* StsDefectType::GetDefectTypeById(Int_t typeId, UInt_t runId)
-{
-  StsDefectType type;
-  FairDbReader<StsDefectType> r_type = *type.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_type.Activate(context, type.GetVersion());
-  return (StsDefectType *)r_type.GetRowByIndex(typeId);
-}
-
 string StsDefectType::GetTableDefinition(const char* Name)
 {
   string sql("create table ");

--- a/dbExamples/cbm_sts/src/StsDefectType.h
+++ b/dbExamples/cbm_sts/src/StsDefectType.h
@@ -39,8 +39,6 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsDefectType* GetDefectTypeById(Int_t defectTypId, UInt_t runId = 0);
-
     Int_t    GetId()              const { return fId; }
     string   GetTypeName()        const { return fTypeName; }
     Double_t GetWeight()          const { return fWeight; }

--- a/dbExamples/cbm_sts/src/StsInspectionImage.cxx
+++ b/dbExamples/cbm_sts/src/StsInspectionImage.cxx
@@ -123,7 +123,7 @@ void StsInspectionImage::clear()
 
 void StsInspectionImage::Print()
 {
-  std::cout << "Sts Inspection Image Instance:"                   << std::endl;
+  std::cout << "Sts Optical Inspection Image Instance:"            << std::endl;
   std::cout << "   Image Id             = "    << fId             << std::endl;
   std::cout << "   Inspection Id        = "    << fInspectionId   << std::endl;
   std::cout << "   ROI X                = "    << fX              << std::endl;
@@ -134,82 +134,20 @@ void StsInspectionImage::Print()
   std::cout                                                       << std::endl;
 }
 
-StsInspectionImage* StsInspectionImage::GetInspectionImageById(Int_t inspectionImageId, UInt_t runId)
-{
-  StsInspectionImage image;
-  FairDbReader<StsInspectionImage> r_image = *image.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_image.Activate(context, image.GetVersion());
-  return (StsInspectionImage *)r_image.GetRowByIndex(inspectionImageId);
-}
-
-
 StsInspectionImage* StsInspectionImage::GetInspectionImage(Int_t inspectionId, Int_t X, Int_t Y, UInt_t runId)
 {
-  StsInspectionImage image;
-  FairDbReader<StsInspectionImage> r_image;
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_image.Activate(context, image.GetVersion());
-  Int_t numRows = r_image.GetNumRows();
-  if (!numRows)
-    return NULL;
-
-  for (Int_t i=0; i < numRows; i++)
+  TObjArray *images = StsInspectionImage::GetArray(inspectionId, runId);
+  for (Int_t i = 0; i<images->GetEntries(); i++)
   {
-    StsInspectionImage *img = (StsInspectionImage*)r_image.GetRow(i);
+    StsInspectionImage *img = (StsInspectionImage*)images->At(i);
     if (!img)
       continue;
 
-    if (img->GetInspectionId() == inspectionId && img->GetX() == X && img->GetY() == Y)
+    if (img->GetX() == X && img->GetY() == Y)
       return img;
   }
 
   return NULL;
-}
-
-TObjArray* StsInspectionImage::GetInspectionImages(Int_t inspectionId, UInt_t runId)
-{
-  StsInspectionImage image;
-  FairDbReader<StsInspectionImage> r_image;
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_image.Activate(context, image.GetVersion());
-  Int_t numRows = r_image.GetNumRows();
-  if (!numRows)
-    return NULL;
-
-  TObjArray* images = new TObjArray(numRows);
-  for (Int_t i=0; i < numRows; i++)
-  {
-    StsInspectionImage *img = (StsInspectionImage*)r_image.GetRow(i);
-    if (!img)
-      continue;
-
-    if (img->GetInspectionId() == inspectionId)
-      images->Add(img);
-  }
-
-  return images;
-}
-
-StsOpticalInspection* StsInspectionImage::GetInspection() {
-  if (!fInspection) fInspection = StsOpticalInspection::GetInspectionById(fInspectionId);
-  return fInspection;
 }
 
 TObjArray* StsInspectionImage::GetDefects() {

--- a/dbExamples/cbm_sts/src/StsInspectionImage.h
+++ b/dbExamples/cbm_sts/src/StsInspectionImage.h
@@ -24,7 +24,7 @@ using TObject::Compare;
     StsInspectionImage(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
               DataType::DataType_t dataid = DataType::kData, 
               const char* name = "StsInspectionImage", 
-              const char* title = "Sts Defect Type Static Data", 
+              const char* title = "Sts Inspection Image Entity", 
               const char* context = "StsDefaultContext", 
               Bool_t ownership=kTRUE);
 
@@ -41,13 +41,18 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsInspectionImage* GetInspectionImageById(Int_t inspectionImageId, UInt_t runId = 0);
+    static TObjArray* GetInspectionImages(Int_t inspectionId, UInt_t runId = 0) {
+      return StsInspectionImage::GetArray(inspectionId, runId);
+    }
+
+    StsOpticalInspection* GetInspection() {
+      if (!fInspection) fInspection = StsOpticalInspection::GetById(fInspectionId);
+      return fInspection;
+    }
+
     static StsInspectionImage* GetInspectionImage(Int_t inspectionId, Int_t X, Int_t Y, UInt_t runId = 0);
-    static TObjArray* GetInspectionImages(Int_t inspectionId, UInt_t runId = 0);
 
-
-    StsOpticalInspection* GetInspection();
-    TObjArray*            GetDefects();
+    TObjArray* GetDefects();
 
     Int_t    GetId()                    const { return fId; }
     Int_t    GetInspectionId()          const { return fInspectionId; }

--- a/dbExamples/cbm_sts/src/StsOpticalInspection.cxx
+++ b/dbExamples/cbm_sts/src/StsOpticalInspection.cxx
@@ -180,7 +180,7 @@ void StsOpticalInspection::Print()
 }
 
 StsSensor* StsOpticalInspection::GetSensor() {
-  if (!fSensor) fSensor = StsSensor::GetSensorById(fSensorId);
+  if (!fSensor) fSensor = StsSensor::GetById(fSensorId);
   return fSensor;
 }
 
@@ -194,48 +194,9 @@ TObjArray* StsOpticalInspection::GetDefects() {
   return fDefects;
 }
 
-StsOpticalInspection* StsOpticalInspection::GetInspectionById(Int_t inspectionId, UInt_t runId)
-{
-  StsOpticalInspection inspection;
-  FairDbReader<StsOpticalInspection> r_inspection = *inspection.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_inspection.Activate(context, inspection.GetVersion());
-  return (StsOpticalInspection *)r_inspection.GetRowByIndex(inspectionId);
-}
-
 TObjArray* StsOpticalInspection::GetInspections(Int_t sensorId, UInt_t runId)
 {
-  StsOpticalInspection inspection;
-  FairDbReader<StsOpticalInspection> r_inspection;
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_inspection.Activate(context, inspection.GetVersion());
-  Int_t numRows = r_inspection.GetNumRows();
-  if (!numRows)
-    return NULL;
-
-  TObjArray* inspections = new TObjArray(numRows);
-  for (Int_t i=0; i < numRows; i++)
-  {
-    StsOpticalInspection *insp = (StsOpticalInspection*)r_inspection.GetRow(i);
-    if (!insp)
-      continue;
-
-    if (insp->GetSensorId() == sensorId)
-      inspections->Add(insp);
-  }
-
-  return inspections;
+  return StsOpticalInspection::GetArray(sensorId, runId);
 }
 
 string StsOpticalInspection::GetTableDefinition(const char* Name)

--- a/dbExamples/cbm_sts/src/StsOpticalInspection.cxx
+++ b/dbExamples/cbm_sts/src/StsOpticalInspection.cxx
@@ -68,7 +68,7 @@ StsOpticalInspection::StsOpticalInspection(FairDbDetector::Detector_t detid,
   fSensor = NULL;
   fInspectionImages = NULL;
   fDefects = NULL;
-  fWarp = new TObject();
+  fWarp = NULL;
 }
 
 StsOpticalInspection::~StsOpticalInspection()
@@ -240,6 +240,12 @@ void StsOpticalInspection::Fill(FairDbResultPool& res_in,
          >> fQualityGrade
          >> fPassed
          >> fComment;
+
+  if (!warpStreamer.AsString().IsNull())
+  {
+    if (!fWarp) fWarp = new TGraph2D();
+    warpStreamer.Fill(fWarp);
+  }
 }
 
 void StsOpticalInspection::Store(FairDbOutTableBuffer& res_out,

--- a/dbExamples/cbm_sts/src/StsOpticalInspection.h
+++ b/dbExamples/cbm_sts/src/StsOpticalInspection.h
@@ -47,7 +47,6 @@ using TObject::Compare;
     TObjArray* GetInspectionImages();
     TObjArray* GetDefects();
 
-    static StsOpticalInspection* GetInspectionById(Int_t inspectionId, UInt_t runId = 0);
     static TObjArray* GetInspections(Int_t sensorId, UInt_t runId = 0);
 
 

--- a/dbExamples/cbm_sts/src/StsOpticalInspection.h
+++ b/dbExamples/cbm_sts/src/StsOpticalInspection.h
@@ -6,6 +6,7 @@
 #include "DataType.h"         
 #include "FairDbGenericParSet.h"
 
+#include "TGraph2D.h"
 #include "TObjArray.h"
 #include "TGeoMaterial.h" 
 #include "Rtypes.h"                     // for Double_t, Int_t, UInt_t, etc
@@ -57,7 +58,7 @@ using TObject::Compare;
     ValTimeStamp GetDate()   const { return fDate; }
     string GetSensorSide()   const { return fSensorSide; }
     Double_t GetMaxWarp()    const { return fMaxWarp; }
-    TObject* GetWarp()       const { return fWarp; }
+    TGraph2D* GetWarp()       const { return fWarp; }
     Double_t GetThickness()  const { return fThickness; }
     Double_t GetQuality()    const { return fQuality; }
     string GetQualityGrade() const { return fQualityGrade; }
@@ -77,7 +78,7 @@ using TObject::Compare;
     void SetDate(ValTimeStamp value)   { fDate = value; }
     void SetSensorSide(string value)   { fSensorSide = value; }
     void SetMaxWarp(Double_t value)    { fMaxWarp = value; }
-    void SetWarp(TObject* value)       { if (fWarp) delete fWarp; fWarp = value ? value->Clone() : NULL; }
+    void SetWarp(TGraph2D* value)      { if (fWarp) delete fWarp; fWarp = value ? new TGraph2D(*value) : NULL; }
     void SetThickness(Double_t value)  { fThickness = value; }
     void SetQuality(Double_t value)    { fQuality = value; } 
     void SetQualityGrade(string value) { fQualityGrade = value; }
@@ -106,7 +107,7 @@ using TObject::Compare;
     ValTimeStamp fDate;
     string fSensorSide;
     Double_t fMaxWarp;
-    TObject* fWarp;
+    TGraph2D* fWarp;
     Double_t fThickness;
     Double_t fQuality;
     string fQualityGrade;

--- a/dbExamples/cbm_sts/src/StsSensor.cxx
+++ b/dbExamples/cbm_sts/src/StsSensor.cxx
@@ -177,57 +177,9 @@ void StsSensor::Print()
   std::cout                                                 << std::endl;
 }
 
-StsSensor* StsSensor::GetSensorById(Int_t sensorId, UInt_t runId)
-{
-  StsSensor sensor;
-  FairDbReader<StsSensor> r_sensor = *sensor.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_sensor.Activate(context, sensor.GetVersion());
-  return (StsSensor *)r_sensor.GetRowByIndex(sensorId);
-}
-
-TObjArray* StsSensor::GetSensors(Int_t batchId, UInt_t runId)
-{
-  StsSensor sensor;
-  FairDbReader<StsSensor> r_sensor;
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_sensor.Activate(context, sensor.GetVersion());
-  Int_t numRows = r_sensor.GetNumRows();
-  if (!numRows)
-    return NULL;
-
-  TObjArray* sensors = new TObjArray(numRows);
-  for (Int_t i=0; i < numRows; i++)
-  {
-    StsSensor *sens = (StsSensor*)r_sensor.GetRow(i);
-    if (!sens)
-      continue;
-
-    if (sens->GetBatchId() == batchId)
-      sensors->Add(sens);
-  }
-
-  return sensors;
-}
-
 TObjArray* StsSensor::GetOpticalInspections()
 {
-  if (!fOpticalInspections)
-  {
-    fOpticalInspections = StsOpticalInspection::GetInspections(fId);
-  }
-
+  if (!fOpticalInspections) fOpticalInspections = StsOpticalInspection::GetInspections(fId);
   return fOpticalInspections;
 }
 

--- a/dbExamples/cbm_sts/src/StsSensor.h
+++ b/dbExamples/cbm_sts/src/StsSensor.h
@@ -44,30 +44,32 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsSensor* GetSensorById(Int_t sensorId, UInt_t runId = 0);
-    static TObjArray* GetSensors(Int_t batchId, UInt_t runId = 0);
+    static TObjArray* GetSensors(Int_t batchId, UInt_t runId = 0) {
+      return StsSensor::GetArray(batchId, runId);
+    }
     
     StsSensorBatch* GetBatch() {
-      if (!fBatch) fBatch = StsSensorBatch::GetBatchById(fBatchId);
+      if (!fBatch) fBatch = StsSensorBatch::GetById(fBatchId);
       return fBatch;
     }
 
-    TObjArray* GetOpticalInspections();
-
     StsSensorLocation* GetLocation() {
-      if (!fLocation) fLocation = StsSensorLocation::GetLocationById(fLocationId);
+      if (!fLocation) fLocation = StsSensorLocation::GetById(fLocationId);
       return fLocation;
     }
 
     StsSensorType* GetType() {
-      if (!fType) fType = StsSensorType::GetTypeById(fTypeId);
+      if (!fType) fType = StsSensorType::GetById(fTypeId);
       return fType;
     }
 
     StsSensorVendor* GetVendor() {
-      if (!fVendor) fVendor = StsSensorVendor::GetVendorById(fVendorId);
+      if (!fVendor) fVendor = StsSensorVendor::GetById(fVendorId);
       return fVendor;
     }
+
+    TObjArray* GetOpticalInspections();
+
 
     Int_t  GetId()           const { return fId; }
     Int_t  GetBatchId()      const { return fBatchId; }

--- a/dbExamples/cbm_sts/src/StsSensorBatch.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorBatch.cxx
@@ -116,21 +116,6 @@ void StsSensorBatch::Print()
   std::cout                                                         << std::endl;
 }
 
-StsSensorBatch* StsSensorBatch::GetBatchById(Int_t batchId, UInt_t runId)
-{
-  StsSensorBatch batch;
-  FairDbReader<StsSensorBatch> r_batch = *batch.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_batch.Activate(context, batch.GetVersion());
-  return (StsSensorBatch *)r_batch.GetRowByIndex(batchId);
-}
-
 TObjArray* StsSensorBatch::GetSensors()
 {
   if (!fSensors)

--- a/dbExamples/cbm_sts/src/StsSensorBatch.h
+++ b/dbExamples/cbm_sts/src/StsSensorBatch.h
@@ -22,7 +22,7 @@ using TObject::Compare;
     StsSensorBatch(FairDbDetector::Detector_t detid = FairDbDetector::kSts, 
               DataType::DataType_t dataid = DataType::kData, 
               const char* name = "StsSensorBatch", 
-              const char* title = "Sts Batch Data", 
+              const char* title = "Sts Sensor Batch Entity", 
               const char* context = "StsDefaultContext", 
               Bool_t ownership=kTRUE);
 
@@ -39,8 +39,7 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsSensorBatch* GetBatchById(Int_t batchId, UInt_t runId = 0);
-    TObjArray*             GetSensors();
+    TObjArray*   GetSensors();
 
     Int_t        GetId()            const { return fId; }
     string       GetNumber()        const { return fNumber; }

--- a/dbExamples/cbm_sts/src/StsSensorLocation.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorLocation.cxx
@@ -112,21 +112,6 @@ void StsSensorLocation::Print()
   std::cout                                                           << std::endl;
 }
 
-StsSensorLocation* StsSensorLocation::GetLocationById(Int_t locationId, UInt_t runId)
-{
-  StsSensorLocation location;
-  FairDbReader<StsSensorLocation> r_location = *location.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_location.Activate(context, location.GetVersion());
-  return (StsSensorLocation *)r_location.GetRowByIndex(locationId);
-}
-
 string StsSensorLocation::GetTableDefinition(const char* Name)
 {
   string sql("create table ");

--- a/dbExamples/cbm_sts/src/StsSensorLocation.h
+++ b/dbExamples/cbm_sts/src/StsSensorLocation.h
@@ -39,8 +39,6 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsSensorLocation* GetLocationById(Int_t locationId, UInt_t runId = 0);
-
     Int_t    GetId()              const { return fId; }
     string   GetLocation()        const { return fLocation; }
     string   GetOwner()           const { return fOwner; }

--- a/dbExamples/cbm_sts/src/StsSensorType.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorType.cxx
@@ -138,21 +138,6 @@ void StsSensorType::clear()
   fComment = "";
 }
 
-StsSensorType* StsSensorType::GetTypeById(Int_t typeId, UInt_t runId)
-{
-  StsSensorType type;
-  FairDbReader<StsSensorType> r_type = *type.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_type.Activate(context, type.GetVersion());
-  return (StsSensorType *)r_type.GetRowByIndex(typeId);
-}
-
 void StsSensorType::Print()
 {
   std::cout << "Sts Sensor Type Instance:"                          << std::endl;

--- a/dbExamples/cbm_sts/src/StsSensorType.h
+++ b/dbExamples/cbm_sts/src/StsSensorType.h
@@ -39,8 +39,6 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsSensorType* GetTypeById(Int_t typeId, UInt_t runId = 0);
-
     Int_t    GetId()            const { return fId; }
     string   GetTypeName()      const { return fTypeName; }
     string   GetProcessing()    const { return fProcessing; }

--- a/dbExamples/cbm_sts/src/StsSensorVendor.cxx
+++ b/dbExamples/cbm_sts/src/StsSensorVendor.cxx
@@ -120,44 +120,17 @@ void StsSensorVendor::Print()
   std::cout                                                         << std::endl;
 }
 
-StsSensorVendor* StsSensorVendor::GetVendorById(Int_t vendorId, UInt_t runId)
-{
-  StsSensorVendor vendor;
-  FairDbReader<StsSensorVendor> r_vendor = *vendor.GetParamReader();
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_vendor.Activate(context, vendor.GetVersion());
-  return (StsSensorVendor *)r_vendor.GetRowByIndex(vendorId);
-}
-
 StsSensorVendor* StsSensorVendor::GetVendorByName(string vendorName, UInt_t runId)
 {
-  StsSensorVendor vendor;
-  FairDbReader<StsSensorVendor> r_vendor;
-
-  ValTimeStamp ts;
-  if (runId)
-    ts = ValTimeStamp(runId);
-  ValCondition context(FairDbDetector::kSts,DataType::kData,ts);
-
-  r_vendor.Activate(context, vendor.GetVersion());
-  Int_t numRows = r_vendor.GetNumRows();
-  if (!numRows)
-    return NULL;
-
-  for (Int_t i=0; i < numRows; i++)
+  TObjArray *vendors = StsSensorVendor::GetArray(-1, runId);
+  for (Int_t i = 0; i<vendors->GetEntries(); i++)
   {
-    StsSensorVendor *vend = (StsSensorVendor*)r_vendor.GetRow(i);
-    if (!vend)
+    StsSensorVendor *vendor = (StsSensorVendor*)vendors->At(i);
+    if (!vendor)
       continue;
 
-    if (vend->GetVendorName() == vendorName)
-      return vend;
+    if (vendor->GetVendorName() == vendorName)
+      return vendor;
   }
 
   return NULL;

--- a/dbExamples/cbm_sts/src/StsSensorVendor.h
+++ b/dbExamples/cbm_sts/src/StsSensorVendor.h
@@ -39,7 +39,6 @@ using TObject::Compare;
     void   Print();
 
     /// Getter Functions
-    static StsSensorVendor* GetVendorById(Int_t vendorId, UInt_t runId = 0);
     static StsSensorVendor* GetVendorByName(string vendorName, UInt_t runId = 0);
 
     Int_t    GetId()              const { return fId; }

--- a/dbInterface/FairDbGenericParSet.h
+++ b/dbInterface/FairDbGenericParSet.h
@@ -60,7 +60,10 @@ class FairDbGenericParSet : public FairDbParSet
     // RuntimeDb IO 
     virtual void clear();
     virtual void fill(UInt_t rid=0);
-    static TObjArray* FillArray(Int_t compId=-1, UInt_t rid=0);
+    static T* Get(UInt_t rid=0);
+    static T* GetById(Int_t id, UInt_t rid=0);
+    static T* GetByIndex(Int_t index, UInt_t rid=0);
+    static TObjArray* GetArray(Int_t compId=-1, UInt_t rid=0);
     virtual void store(UInt_t rid=0);
     static void StoreArray(TObjArray *array, Int_t compId=-1, UInt_t rid=0);
 

--- a/dbInterface/FairDbGenericParSet.tpl
+++ b/dbInterface/FairDbGenericParSet.tpl
@@ -163,12 +163,36 @@ void FairDbGenericParSet<T>::fill(UInt_t rid)
 }
 
 template<typename T>
-TObjArray* FairDbGenericParSet<T>::FillArray(Int_t compId, UInt_t rid)
+T* FairDbGenericParSet<T>::Get(UInt_t rid)
+{
+  T* instance = new T();
+  instance->fill(rid);
+  return instance;
+}
+
+template<typename T>
+T* FairDbGenericParSet<T>::GetById(Int_t id, UInt_t rid)
+{
+  return FairDbGenericParSet<T>::GetByIndex(id, rid);
+}
+
+template<typename T>
+T* FairDbGenericParSet<T>::GetByIndex(Int_t index, UInt_t rid)
+{
+  T instance;
+  FairDbReader<T> paramReader;
+
+  paramReader.Activate( instance.GetContext(rid), instance.GetVersion());
+  return (T*)paramReader.GetRowByIndex(index);
+}
+
+template<typename T>
+TObjArray* FairDbGenericParSet<T>::GetArray(Int_t compId, UInt_t rid)
 {
   T instance;
   FairDbReader<T> paramReader;
   
-  paramReader.Activate( ((FairDbGenericParSet<T>) instance).GetContext(rid), instance.GetVersion());
+  paramReader.Activate(instance.GetContext(rid), instance.GetVersion());
   Int_t numRows = paramReader.GetNumRows();
   if (!numRows)
     return NULL;
@@ -190,7 +214,12 @@ TObjArray* FairDbGenericParSet<T>::FillArray(Int_t compId, UInt_t rid)
     result->Add(inst);
   }
 
-  return result;
+  if (result->GetEntries()) {
+    return result;
+  } else {
+    delete result;
+    return NULL;
+  }
 }
 
 template<typename T>


### PR DESCRIPTION
This PR adds 3 more static getters to the FairDbGenericParSet<T> base class for indexed access.
`FillArray` is renamed to `GetArray`
This addition allows to remove a lot of code repetition in the inheriting classes.