### PR TITLE
FairDbResult: fix not setting composite id from valrec

### DIFF
--- a/dbInterface/FairDbResult.cxx
+++ b/dbInterface/FairDbResult.cxx
@@ -1008,6 +1008,7 @@ FairDbResultNonCombo::FairDbResultNonCombo(FairDbResultPool* resultSet,
 
     //cout << " -I- FairDbResultNonCombo:: ObjTableMap::Fill() called  " << endl;
     row->Fill(rs,vrec);
+    if ( vrec) { row->SetComboNo(vrec->GetAggregateNo()); }
     //cout << " -I- FairDbResultNonCombo:: ObjTableMap::Fill() IO done ...  " << endl;
 
     if ( vrec) { FairDbStopWatchManager::gStopWatchManager.StartSubWatch(2); }


### PR DESCRIPTION
When reading data from db, the objects created do not get their `composite id`, aka `combo no`, aka `aggregate no` set.
This PR fixes this