### PR TITLE
Add FairDbRelationalParSet and example implementing classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ install(FILES "dbUtils/FairDbLogBFormat.h" DESTINATION include)
 install(FILES "dbInterface/FairDbReader.tpl" DESTINATION include)
 install(FILES "dbInterface/FairDbWriter.tpl" DESTINATION include)
 install(FILES "dbInterface/FairDbGenericParSet.tpl" DESTINATION include)
+install(FILES "dbInterface/FairDbRelationalParSet.tpl" DESTINATION include)
 install(FILES "dbInput/db_detector_def.h" DESTINATION include)
 install(FILES "dbInput/prepare_db.sql" DESTINATION share/dbInput)
 
@@ -125,7 +126,7 @@ install(DIRECTORY "db3rdParty/jsoncpp/json" DESTINATION include)
 
 CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
 set(HEADERS ${HEADERS} ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbReader.h ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbWriter.h
-  ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbGenericParSet.h)
+  ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbGenericParSet.h ${CMAKE_SOURCE_DIR}/dbase/dbInterface/FairDbRelationalParSet.h)
 set(SRCS ${SRCS} db3rdParty/jsoncpp/jsoncpp.cpp)
 
 set(LINKDEF FairDBLinkDef.h)

--- a/dbExamples/CMakeLists.txt
+++ b/dbExamples/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory (basics)
 add_subdirectory (advanced)
 add_subdirectory (cbm_sts)
-
+add_subdirectory (FairDbCbmSts)

--- a/dbExamples/FairDbCbmSts/CMakeLists.txt
+++ b/dbExamples/FairDbCbmSts/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory (src)

--- a/dbExamples/FairDbCbmSts/src/CMakeLists.txt
+++ b/dbExamples/FairDbCbmSts/src/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Create a library called "FairDbCbmSts" which includes the source files given in
+# the array .
+
+Set(INCLUDE_DIRECTORIES
+  ${BASE_INCLUDE_DIRECTORIES}
+  
+  ${CMAKE_SOURCE_DIR}/dbase/db3rdParty/jsoncpp/
+  ${CMAKE_SOURCE_DIR}/dbase/dbExamples/FairDbCbmSts/src
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${Boost_INCLUDE_DIR}
+)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${ROOT_LIBRARY_DIR}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+set(HEADERS
+  StsSensor.h
+  StsSensorBatch.h
+)
+
+set(SRCS
+  StsSensor.cxx
+  StsSensorBatch.cxx
+)
+
+set(LINKDEF FairDbCbmStsLinkDef.h)
+Set(LIBRARY_NAME FairDbCbmSts)
+
+Set(DEPENDENCIES Base ParBase FairDB)
+
+GENERATE_LIBRARY()
+

--- a/dbExamples/FairDbCbmSts/src/FairDbCbmStsLinkDef.h
+++ b/dbExamples/FairDbCbmSts/src/FairDbCbmStsLinkDef.h
@@ -1,0 +1,22 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+
+#pragma link C++ class FairDbReader<StsSensor>+;
+#pragma link C++ class FairDbWriter<StsSensor>+;
+#pragma link C++ class FairDbGenericParSet<StsSensor>+;
+#pragma link C++ class FairDbRelationalParSet<StsSensor>+;
+#pragma link C++ class StsSensor+;
+
+#pragma link C++ class FairDbReader<StsSensorBatch>+;
+#pragma link C++ class FairDbWriter<StsSensorBatch>+;
+#pragma link C++ class FairDbGenericParSet<StsSensorBatch>+;
+#pragma link C++ class FairDbRelationalParSet<StsSensorBatch>+;
+#pragma link C++ class StsSensorBatch+;
+
+
+#endif
+

--- a/dbExamples/FairDbCbmSts/src/StsSensor.cxx
+++ b/dbExamples/FairDbCbmSts/src/StsSensor.cxx
@@ -1,0 +1,133 @@
+#include "StsSensor.h"
+#include "StsSensorBatch.h"
+
+ClassImp(StsSensor);
+
+static FairDbGenericParRegistry<StsSensor> ClassRegistry("StsSensor", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class FairDbGenericParSet<StsSensor>;
+
+#include "FairDbRelationalParSet.tpl"
+template class FairDbRelationalParSet<StsSensor>;
+
+#include "FairDbReader.tpl"
+template class FairDbReader<StsSensor>;
+
+#include "FairDbWriter.tpl"
+template class FairDbWriter<StsSensor>;
+
+StsSensor::StsSensor(FairDbDetector::Detector_t detid,
+              DataType::DataType_t dataid,
+              const char* name,
+              const char* title,
+              const char* context,
+              Bool_t ownership):
+  FairDbRelationalParSet(detid, dataid, name, title, context, ownership),
+  fBatchId(0),
+  fSUID("")
+{
+}
+
+StsSensor::~StsSensor()
+{
+}
+
+void StsSensor::Print()
+{
+  std::cout << "Sts Sensor Entity Instance:" << std::endl;
+
+  std::cout << "Id = " << fId << std::endl;
+  std::cout << "SUID = " << fSUID << std::endl;
+
+  std::cout << std::endl;
+}
+
+const StsSensorBatch* StsSensor::GetBatch() {
+  if (!fBatch) fBatch = StsSensorBatch::GetById(fBatchId);
+  return fBatch;
+}
+
+string StsSensor::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO             INT NOT NULL,";
+  sql += "  ROW_ID            INT NOT NULL,";
+
+  sql += "  ID INT NOT NULL,";
+  sql += "  BATCH_ID INT,";
+  sql += "  SUID TEXT,";
+
+  sql += "  primary key(SEQNO,ROW_ID))";
+  return sql;
+}
+
+void StsSensor::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId;
+  res_in >> fBatchId;
+  res_in >> fSUID;
+}
+
+void StsSensor::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+  res_out << fId;
+  res_out << fBatchId;
+  res_out << fSUID;
+}
+
+StsSensor::StsSensor(const StsSensor& from){
+  SetCompId(from.GetCompId());
+
+  SetId(from.GetId());
+  SetBatchId(from.GetBatchId());
+  SetSUID(from.GetSUID());
+}
+
+StsSensor& StsSensor::operator=(const StsSensor& from){
+  SetCompId(from.GetCompId());
+
+  SetId(from.GetId());
+  SetBatchId(from.GetBatchId());
+  SetSUID(from.GetSUID());
+
+  return *this;
+}
+
+TObjArray* StsSensor::GetByBatchId(Int_t BatchId, UInt_t rid)
+{
+  return GetBy(
+    [&BatchId](StsSensor *inst) -> bool
+      {
+        return BatchId == inst->GetBatchId();
+      });
+}
+
+TObjArray* StsSensor::GetBySUID(string SUID, UInt_t rid)
+{
+  return GetBy(
+    [&SUID](StsSensor *inst) -> bool
+      {
+        return SUID == inst->GetSUID();
+      });
+}
+
+void StsSensor::FillFromJson(Json::Value& json)
+{
+  SetId(json["Id"].asInt());
+  SetBatchId(json["BatchId"].asInt());
+  SetSUID(json["SUID"].asString());
+}
+
+void StsSensor::StoreToJson(Json::Value& json)
+{
+  json["Id"] = GetId();
+  json["BatchId"] = fBatchId;
+  json["SUID"] = fSUID;
+
+  json["Batch"] = Json::Value(Json::nullValue);
+}

--- a/dbExamples/FairDbCbmSts/src/StsSensor.h
+++ b/dbExamples/FairDbCbmSts/src/StsSensor.h
@@ -1,0 +1,68 @@
+#ifndef STSSENSOR_H
+#define STSSENSOR_H
+
+#include "DataType.h"
+#include "FairDbRelationalParSet.h"
+#include "TString.h"
+#include "TObjArray.h"
+#include "Rtypes.h"
+#include "json/json.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+class StsSensorBatch;
+
+class StsSensor : public FairDbRelationalParSet<StsSensor>
+{
+  using TObject::Compare;
+
+  public :
+    StsSensor(FairDbDetector::Detector_t detid = FairDbDetector::kSts,
+          DataType::DataType_t dataid = DataType::kData,
+          const char* name = "StsSensor",
+          const char* title = "Sts Sensor Entity",
+          const char* context = "StsSensorDefaultContext",
+          Bool_t ownership=kTRUE);
+
+    virtual ~StsSensor(void);
+    StsSensor(const StsSensor& from);
+    StsSensor& operator=(const StsSensor& from);
+
+    // Dump Object
+    void   Print();
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+    const StsSensorBatch* GetBatch();
+
+    static TObjArray* GetByBatchId(Int_t BatchId, UInt_t rid=0);
+    static TObjArray* GetBySUID(string SUID, UInt_t rid=0);
+
+    Int_t GetBatchId() const { return fBatchId; }
+    string GetSUID() const { return fSUID; }
+
+    void SetBatchId(Int_t value) { fBatchId = value; }
+    void SetSUID(string value) { fSUID = value; }
+
+    virtual void FillFromJson(Json::Value& json);
+    virtual void StoreToJson(Json::Value& json);
+
+  private:
+    StsSensorBatch* fBatch; //! transient relation to StsSensorBatch, Has One
+
+    Int_t fBatchId;
+    string fSUID;
+
+    ClassDef(StsSensor, 1); // ROOT class definition
+};
+
+#endif /* !STSSENSOR_H */

--- a/dbExamples/FairDbCbmSts/src/StsSensorBatch.cxx
+++ b/dbExamples/FairDbCbmSts/src/StsSensorBatch.cxx
@@ -1,0 +1,138 @@
+#include "StsSensorBatch.h"
+#include "StsSensor.h"
+
+ClassImp(StsSensorBatch);
+
+static FairDbGenericParRegistry<StsSensorBatch> ClassRegistry("StsSensorBatch", FairDbDetector::kSts, DataType::kData);
+
+#include "FairDbGenericParSet.tpl"
+template class FairDbGenericParSet<StsSensorBatch>;
+
+#include "FairDbRelationalParSet.tpl"
+template class FairDbRelationalParSet<StsSensorBatch>;
+
+#include "FairDbReader.tpl"
+template class FairDbReader<StsSensorBatch>;
+
+#include "FairDbWriter.tpl"
+template class FairDbWriter<StsSensorBatch>;
+
+StsSensorBatch::StsSensorBatch(FairDbDetector::Detector_t detid,
+              DataType::DataType_t dataid,
+              const char* name,
+              const char* title,
+              const char* context,
+              Bool_t ownership):
+  FairDbRelationalParSet(detid, dataid, name, title, context, ownership),
+  fSensors(NULL),
+  fNumber(""),
+  fDate(ValTimeStamp::GetBOT()),
+  fComment("")
+{
+}
+
+StsSensorBatch::~StsSensorBatch()
+{
+  delete fSensors;
+}
+
+void StsSensorBatch::Print()
+{
+  std::cout << "Sts Sensor Batch Entity Instance:" << std::endl;
+
+  std::cout << "Id = " << fId << std::endl;
+  std::cout << "Number = " << fNumber << std::endl;
+  std::cout << "Date = " << fDate << std::endl;
+  std::cout << "Comment = " << fComment << std::endl;
+
+  std::cout << std::endl;
+}
+
+const TObjArray* StsSensorBatch::GetSensors()
+{
+  if (!fSensors) fSensors = StsSensor::GetByBatchId(fId);
+  return fSensors;
+}
+
+string StsSensorBatch::GetTableDefinition(const char* Name)
+{
+  string sql("create table ");
+  if ( Name ) { sql += Name; }
+  else { sql += GetTableName(); }
+  sql += "( SEQNO             INT NOT NULL,";
+  sql += "  ROW_ID            INT NOT NULL,";
+
+  sql += "  ID INT NOT NULL,";
+  sql += "  NUMBER TEXT,";
+  sql += "  DATE DATETIME,";
+  sql += "  COMMENT TEXT,";
+
+  sql += "  primary key(SEQNO,ROW_ID))";
+  return sql;
+}
+
+void StsSensorBatch::Fill(FairDbResultPool& res_in,
+                        const FairDbValRecord* valrec)
+{
+  res_in >> fId;
+  res_in >> fNumber;
+  res_in >> fDate;
+  res_in >> fComment;
+}
+
+void StsSensorBatch::Store(FairDbOutTableBuffer& res_out,
+                         const FairDbValRecord* valrec) const
+{
+
+  res_out << fId;
+  res_out << fNumber;
+  res_out << fDate;
+  res_out << fComment;
+}
+
+StsSensorBatch::StsSensorBatch(const StsSensorBatch& from){
+  SetCompId(from.GetCompId());
+
+  SetId(from.GetId());
+  SetNumber(from.GetNumber());
+  SetDate(from.GetDate());
+  SetComment(from.GetComment());
+}
+
+StsSensorBatch& StsSensorBatch::operator=(const StsSensorBatch& from){
+  SetCompId(from.GetCompId());
+
+  SetId(from.GetId());
+  SetNumber(from.GetNumber());
+  SetDate(from.GetDate());
+  SetComment(from.GetComment());
+
+  return *this;
+}
+
+TObjArray* StsSensorBatch::GetByNumber(string Number, UInt_t rid)
+{
+  return GetBy(
+    [&Number](StsSensorBatch *inst) -> bool
+      {
+        return Number == inst->GetNumber();
+      });
+}
+
+void StsSensorBatch::FillFromJson(Json::Value& json)
+{
+  SetId(json["Id"].asInt());
+  SetNumber(json["Number"].asString());
+  SetDate(json["Date"].asInt());
+  SetComment(json["Comment"].asString());
+}
+
+void StsSensorBatch::StoreToJson(Json::Value& json)
+{
+  json["Id"] = GetId();
+  json["Number"] = fNumber;
+  json["Date"] = (Int_t) fDate;
+  json["Comment"] = fComment;
+
+  json["Sensors"] = Json::Value(Json::nullValue);
+}

--- a/dbExamples/FairDbCbmSts/src/StsSensorBatch.h
+++ b/dbExamples/FairDbCbmSts/src/StsSensorBatch.h
@@ -1,0 +1,70 @@
+#ifndef STSSENSORBATCH_H
+#define STSSENSORBATCH_H
+
+#include "DataType.h"
+#include "FairDbRelationalParSet.h"
+#include "TString.h"
+#include "TObjArray.h"
+#include "Rtypes.h"
+#include "json/json.h"
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+class StsSensor;
+
+class StsSensorBatch : public FairDbRelationalParSet<StsSensorBatch>
+{
+  using TObject::Compare;
+
+  public :
+    StsSensorBatch(FairDbDetector::Detector_t detid = FairDbDetector::kSts,
+          DataType::DataType_t dataid = DataType::kData,
+          const char* name = "StsSensorBatch",
+          const char* title = "Sts Sensor Batch Entity",
+          const char* context = "StsSensorDefaultContext",
+          Bool_t ownership=kTRUE);
+
+    virtual ~StsSensorBatch(void);
+    StsSensorBatch(const StsSensorBatch& from);
+    StsSensorBatch& operator=(const StsSensorBatch& from);
+
+    // Dump Object
+    void   Print();
+
+    // Add-ons: SQL descriptors for the parameter class
+    virtual std::string GetTableDefinition(const char* Name = 0);
+
+    // Atomic IO (intrinsic)
+    virtual void Fill(FairDbResultPool& res_in,
+                      const FairDbValRecord* valrec);
+    virtual void Store(FairDbOutTableBuffer& res_out,
+                       const FairDbValRecord* valrec) const;
+
+    const TObjArray* GetSensors();
+
+    static TObjArray* GetByNumber(string Number, UInt_t rid=0);
+
+    string GetNumber() const { return fNumber; }
+    ValTimeStamp GetDate() const { return fDate; }
+    string GetComment() const { return fComment; }
+
+    void SetNumber(string value) { fNumber = value; }
+    void SetDate(ValTimeStamp value) { fDate = value; }
+    void SetComment(string value) { fComment = value; }
+
+    virtual void FillFromJson(Json::Value& json);
+    virtual void StoreToJson(Json::Value& json);
+
+  private:
+    TObjArray* fSensors; //! transient relation to StsSensor, Has Many
+
+    string fNumber;
+    ValTimeStamp fDate;
+    string fComment;
+
+    ClassDef(StsSensorBatch, 1); // ROOT class definition
+};
+
+#endif /* !STSSENSORBATCH_H */

--- a/dbInterface/FairDbRelationalParSet.h
+++ b/dbInterface/FairDbRelationalParSet.h
@@ -1,0 +1,52 @@
+#ifndef FAIRDBRELATIONALPARSET_H
+#define FAIRDBRELATIONALPARSET_H
+
+
+#include "DataType.h"
+#include "FairDbGenericParSet.h"
+#include "TString.h"
+#include "TObjArray.h"
+#include "Rtypes.h"
+#include "json/json.h"
+
+#include <iostream>
+#include <string>
+
+template <typename T>
+class FairDbRelationalParSet : public FairDbGenericParSet<T>
+{
+  public :
+    FairDbRelationalParSet();
+    FairDbRelationalParSet(FairDbDetector::Detector_t detid, DataType::DataType_t dataid, 
+                        const char* name, const char* title, const char* context, Bool_t ownership=kFALSE);
+
+    virtual ~FairDbRelationalParSet(void);
+
+    UInt_t GetIndex(UInt_t /*def*/) const { return fId; }
+    
+    Int_t GetId() const { return fId; }
+    void SetId(Int_t value) { fId = value; this->SetCompId(fId); }
+
+    static T* GetById(Int_t id, UInt_t rid=0);
+    static TObjArray* GetByIds(Int_t* ids, UInt_t count, UInt_t rid=0);
+
+    static T* FromJsonString(string& jsonString);
+    static T* FromJson(Json::Value& json);
+    static TObjArray* FromJsonArray(Json::Value& jsonArray);
+    string ToJsonString();
+    Json::Value ToJson();
+    static Json::Value ToJsonArray(TObjArray* array);
+
+    virtual void FillFromJson(Json::Value& json) { ; }
+    virtual void StoreToJson(Json::Value& json) { ; }
+
+  protected:
+    Int_t fId;
+
+  private:
+    ClassDefT(FairDbRelationalParSet<T>,0); // ROOT template class definition
+};
+ClassDefT2(FairDbRelationalParSet,T)
+
+#endif /* !FAIRDBRELATIONALPARSET_H */
+

--- a/dbInterface/FairDbRelationalParSet.tpl
+++ b/dbInterface/FairDbRelationalParSet.tpl
@@ -1,0 +1,139 @@
+#include "FairDbRelationalParSet.h"
+
+ClassImpT(FairDbRelationalParSet,T)
+
+template<typename T>
+FairDbRelationalParSet<T>::FairDbRelationalParSet():
+  FairDbGenericParSet<T>(),
+  fId(0)
+{
+  this->SetCompId(fId);
+}
+
+template<typename T>
+FairDbRelationalParSet<T>::FairDbRelationalParSet(FairDbDetector::Detector_t detid,
+              DataType::DataType_t dataid,
+              const char* name,
+              const char* title,
+              const char* context,
+              Bool_t ownership):
+  FairDbGenericParSet<T>(detid, dataid, name, title, context, ownership),
+  fId(0)
+{
+  this->SetCompId(fId);
+}
+
+template<typename T>
+FairDbRelationalParSet<T>::~FairDbRelationalParSet()
+{
+}
+
+template<typename T>
+T* FairDbRelationalParSet<T>::GetById(Int_t id, UInt_t rid)
+{
+  return T::GetByIndex(id, rid);
+}
+
+template<typename T>
+TObjArray* FairDbRelationalParSet<T>::GetByIds(Int_t* ids, UInt_t count, UInt_t rid)
+{
+  if (!ids)
+    return NULL;
+
+  return T::GetBy(
+    [&ids, &count](T *inst) -> bool
+      {
+        for (Int_t i=0; i < count; i++)
+        {
+          if (ids[i] == inst->GetId())
+          {
+            return true;
+          }
+        }
+        return false;
+      });
+}
+
+template<typename T>
+T* FairDbRelationalParSet<T>::FromJsonString(string& jsonString)
+{
+  Json::Value json;
+  string error;
+  Json::CharReaderBuilder readerBuilder;
+  Json::CharReader *reader = readerBuilder.newCharReader();
+  Bool_t result = reader->parse(jsonString.data(), jsonString.data() + jsonString.size(), &json, &error);
+  if (!result)
+  {
+    cout << "FairDbRelationalParSet<T>::FromJsonString" << endl;
+    cout << error << endl;
+    return NULL;
+  }
+  delete reader;
+
+  return FromJson(json);
+}
+
+template<typename T>
+T* FairDbRelationalParSet<T>::FromJson(Json::Value& json)
+{
+  T* instance = new T();
+  instance->FillFromJson(json);
+  return instance;
+}
+
+template<typename T>
+TObjArray* FairDbRelationalParSet<T>::FromJsonArray(Json::Value& jsonArray)
+{
+  TObjArray *result = NULL;
+  Int_t count = jsonArray.size();
+
+  if (count)
+  {
+    result = new TObjArray(count);
+    for (Int_t i = 0; i < count; i++)
+    {
+      result->Add(FromJson(jsonArray[i]));
+    }
+  }
+
+  return result;
+}
+
+template<typename T>
+string FairDbRelationalParSet<T>::ToJsonString()
+{
+  ostringstream stream;
+  Json::StreamWriterBuilder writerBuilder;
+  Json::StreamWriter *writer = writerBuilder.newStreamWriter();
+
+  writer->write(ToJson(), &stream);
+  delete writer;
+  return stream.str();
+}
+
+template<typename T>
+Json::Value FairDbRelationalParSet<T>::ToJson()
+{
+  Json::Value result;
+
+  StoreToJson(result);
+
+  return result;
+}
+
+template<typename T>
+Json::Value FairDbRelationalParSet<T>::ToJsonArray(TObjArray* array)
+{
+  Json::Value jsonArray(Json::arrayValue);
+  if (array)
+  {
+    Int_t count = array->GetEntries();
+    jsonArray.resize(count);
+    for (Int_t i = 0; i < count; i++)
+    {
+      jsonArray[i] = ((T*) array->At(i))->ToJson();
+    }
+  }
+
+  return jsonArray;
+}


### PR DESCRIPTION
Hi,

I was able to offload the relational model implementation and json serialization/deserialization in a separate class, in order not to pollute the GenericParSet. Everything works fine on my side and implementing classes look much cleaner. However there is a small tradeoff: every class now need to define +1 line totalling in 5 in a `LinkDef.h` file:
```
#pragma link C++ class FairDbReader<StsSensorBatch>+;
#pragma link C++ class FairDbWriter<StsSensorBatch>+;
#pragma link C++ class FairDbGenericParSet<StsSensorBatch>+;
#pragma link C++ class FairDbRelationalParSet<StsSensorBatch>+;
#pragma link C++ class StsSensorBatch+;
```

But I think it should be alright in case of generated code.