### PR TITLE
Add STL streamers

### DIFF
--- a/dbInterface/FairDb.cxx
+++ b/dbInterface/FairDb.cxx
@@ -11,6 +11,7 @@
 
 #include "TBufferFile.h"
 #include "TVirtualStreamerInfo.h"
+#include "TClass.h"
 
 #include "FairUtilStream.h"
 #include "FairDbLogService.h"
@@ -344,4 +345,99 @@ TString FairDb::StreamAsString(const TObject* obj, Int_t& size)
   return str_hex.c_str();
 }
 
+TString FairDb::StreamAsString(const void* anyObject, std::string signature)
+{
+  if (!anyObject)
+  {
+    return "";
+  }
 
+  TBufferFile b_write(TBuffer::kWrite);
+  TClass *cls = TClass(signature.c_str()).GetActualClass(anyObject);
+  cls->Streamer(const_cast<void *>(anyObject), b_write);
+  Char_t* buff =  b_write.Buffer();
+  Int_t   ll   = b_write.Length();
+
+  static std::string astr;
+  Util::BinToHex(buff,ll,astr);
+
+  return astr.c_str();
+}
+
+/// vector<>
+TString FairDb::StreamAsString(const std::vector<Bool_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<Bool_t>");
+}
+
+TString FairDb::StreamAsString(const std::vector<Short_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<Short_t>");
+}
+
+TString FairDb::StreamAsString(const std::vector<UShort_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<UShort_t>");
+}
+
+TString FairDb::StreamAsString(const std::vector<Int_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<Int_t>");
+}
+
+TString FairDb::StreamAsString(const std::vector<UInt_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<UInt_t>");
+}
+
+TString FairDb::StreamAsString(const std::vector<Float_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<Float_t>");
+}
+
+TString FairDb::StreamAsString(const std::vector<Double_t> vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector<Double_t>");
+}
+
+/// vector< vector<> >
+TString FairDb::StreamAsString(const std::vector< std::vector<Bool_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<Bool_t> >");
+}
+
+TString FairDb::StreamAsString(const std::vector< std::vector<Short_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<Short_t> >");
+}
+
+TString FairDb::StreamAsString(const std::vector< std::vector<UShort_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<UShort_t> >");
+}
+
+TString FairDb::StreamAsString(const std::vector< std::vector<Int_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<Int_t> >");
+}
+
+TString FairDb::StreamAsString(const std::vector< std::vector<UInt_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<UInt_t> >");
+}
+
+TString FairDb::StreamAsString(const std::vector< std::vector<Float_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<Float_t> >");
+}
+
+TString FairDb::StreamAsString(const std::vector< std::vector<Double_t> > vector)
+{
+  return FairDb::StreamAsString(&vector, "std::vector< std::vector<Double_t> >");
+}
+
+/// map
+TString FairDb::StreamAsString(const std::map<std::string, TObject> map)
+{
+  return FairDb::StreamAsString(&map, "std::map<std::string, TObject>");
+}

--- a/dbInterface/FairDb.h
+++ b/dbInterface/FairDb.h
@@ -19,6 +19,8 @@
 #include "TString.h"                    // for TString
 
 #include <string>                       // for string
+#include <vector>
+#include <map>
 
 // IWYU pragma: no_include "Rtypes.h"
 
@@ -98,6 +100,29 @@ TString StreamAsString(const Bool_t* arr, Int_t size);
 TString StreamAsString(const Float_t* arr, Int_t size);
 TString StreamAsString(const Double_t* arr, Int_t size);
 TString StreamAsString(const TObject* obj, Int_t& size);
+
+TString StreamAsString(const void* anyObject, std::string signature);
+
+/// vector<>
+TString StreamAsString(const std::vector<Bool_t> vector);
+TString StreamAsString(const std::vector<Short_t> vector);
+TString StreamAsString(const std::vector<UShort_t> vector);
+TString StreamAsString(const std::vector<Int_t> vector);
+TString StreamAsString(const std::vector<UInt_t> vector);
+TString StreamAsString(const std::vector<Float_t> vector);
+TString StreamAsString(const std::vector<Double_t> vector);
+
+/// vector< vector<> >
+TString StreamAsString(const std::vector< std::vector<Bool_t> > vector);
+TString StreamAsString(const std::vector< std::vector<Short_t> > vector);
+TString StreamAsString(const std::vector< std::vector<UShort_t> > vector);
+TString StreamAsString(const std::vector< std::vector<Int_t> > vector);
+TString StreamAsString(const std::vector< std::vector<UInt_t> > vector);
+TString StreamAsString(const std::vector< std::vector<Float_t> > vector);
+TString StreamAsString(const std::vector< std::vector<Double_t> > vector);
+
+/// map
+TString StreamAsString(const std::map<std::string, TObject> map);
 
 // Logging System
 void SetLogLevel(Int_t level);

--- a/dbInterface/FairDbStreamer.cxx
+++ b/dbInterface/FairDbStreamer.cxx
@@ -26,6 +26,22 @@ FairDbStreamer::FairDbStreamer()
 {
 }
 
+FairDbStreamer::FairDbStreamer(TString string)
+  : TObject(),
+    fString(string),
+    fSize(0),
+    fType(FairDb::kInt)
+{
+}
+
+FairDbStreamer::FairDbStreamer(std::string string)
+  : TObject(),
+    fString(string),
+    fSize(0),
+    fType(FairDb::kInt)
+{
+}
+
 FairDbStreamer::FairDbStreamer(const TObject* obj,FairDb::DataTypes type)
   : TObject()
     //    fString(FairDb::StreamAsString(obj,fSize)), 
@@ -130,6 +146,14 @@ FairDbStreamer::FairDbStreamer(const Double_t* iarr, Int_t size, FairDb::DataTyp
 */
 }
 
+FairDbStreamer::FairDbStreamer(const void* anyObject, std::string signature, FairDb::DataTypes type)
+  : TObject(),
+    fString(FairDb::StreamAsString(anyObject, signature)),
+    fSize(),
+    fType(type)
+{
+
+}
 
 
 FairDbStreamer::FairDbStreamer(const FairDbStreamer& from)
@@ -288,4 +312,98 @@ void FairDbStreamer::Fill(TObject* obj)
   Util::BinFromHex(str_hex,read_buf);
   TBufferFile b_read(TBuffer::kRead,halb, read_buf,kFALSE);
   obj->Streamer(b_read);
+}
+
+void FairDbStreamer::Fill(void* anyObject, std::string signature)
+{
+  if (fString.IsNull())
+    return;
+
+  std::string str_hex(fString.Data());
+  size_t halb = str_hex.length()/2;
+  UChar_t read_buf[halb];
+  Util::BinFromHex(str_hex,read_buf);
+  TBufferFile b_read(TBuffer::kRead,halb, read_buf,kFALSE);
+
+  TClass *cls = TClass(signature.c_str()).GetActualClass(anyObject);
+  cls->Streamer(anyObject, b_read);
+}
+
+
+/// vector<>
+void FairDbStreamer::Fill(std::vector<Bool_t> &vector)
+{
+  Fill(&vector, "std::vector<Bool_t>");
+}
+
+void FairDbStreamer::Fill(std::vector<Short_t> &vector)
+{
+  Fill(&vector, "std::vector<Short_t>");
+}
+
+void FairDbStreamer::Fill(std::vector<UShort_t> &vector)
+{
+  Fill(&vector, "std::vector<UShort_t>");
+}
+
+void FairDbStreamer::Fill(std::vector<Int_t> &vector)
+{
+  Fill(&vector, "std::vector<Int_t>");
+}
+
+void FairDbStreamer::Fill(std::vector<UInt_t> &vector)
+{
+  Fill(&vector, "std::vector<UInt_t>");
+}
+
+void FairDbStreamer::Fill(std::vector<Float_t> &vector)
+{
+  Fill(&vector, "std::vector<Float_t>");
+}
+
+void FairDbStreamer::Fill(std::vector<Double_t> &vector)
+{
+  Fill(&vector, "std::vector<Double_t>");
+}
+
+/// vector< vector<> >
+void FairDbStreamer::Fill(std::vector< std::vector<Bool_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<Bool_t> >");
+}
+
+void FairDbStreamer::Fill(std::vector< std::vector<Short_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<Short_t> >");
+}
+
+void FairDbStreamer::Fill(std::vector< std::vector<UShort_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<UShort_t> >");
+}
+
+void FairDbStreamer::Fill(std::vector< std::vector<Int_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<Int_t> >");
+}
+
+void FairDbStreamer::Fill(std::vector< std::vector<UInt_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<UInt_t> >");
+}
+
+void FairDbStreamer::Fill(std::vector< std::vector<Float_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<Float_t> >");
+}
+
+void FairDbStreamer::Fill(std::vector< std::vector<Double_t> > &vector)
+{
+  Fill(&vector, "std::vector< std::vector<Double_t> >");
+}
+
+/// map
+void FairDbStreamer::Fill(std::map<std::string, TObject> &map)
+{
+  Fill(&map, "std::map<std::string, TObject>");
 }

--- a/dbInterface/FairDbStreamer.h
+++ b/dbInterface/FairDbStreamer.h
@@ -14,7 +14,8 @@
 #include <stddef.h>                     // for NULL
 #include <cassert>                      // for assert
 #include <string>                       // for string
-
+#include <vector>
+#include <map>
 
 #include "FairDb.h"
 
@@ -25,6 +26,8 @@ class FairDbStreamer : public TObject
 
     // Constructors and destructors.
     FairDbStreamer();
+    FairDbStreamer(TString string);
+    FairDbStreamer(std::string string);
     FairDbStreamer(const TObject* obj,  FairDb::DataTypes type=FairDb::kBinary);
     FairDbStreamer(const Int_t* iarr, Int_t size, FairDb::DataTypes type=FairDb::kInt);
     FairDbStreamer(const UInt_t* iarr, Int_t size, FairDb::DataTypes type=FairDb::kInt);
@@ -33,6 +36,8 @@ class FairDbStreamer : public TObject
     FairDbStreamer(const Bool_t* iarr, Int_t size, FairDb::DataTypes type=FairDb::kInt);
     FairDbStreamer(const Float_t* iarr, Int_t size, FairDb::DataTypes type=FairDb::kInt);
     FairDbStreamer(const Double_t* iarr, Int_t size, FairDb::DataTypes type=FairDb::kInt);
+
+    FairDbStreamer(const void* anyObject, std::string signature, FairDb::DataTypes type=FairDb::kBinary);
 
     FairDbStreamer(const FairDbStreamer& from);
     FairDbStreamer& operator=(const FairDbStreamer&);
@@ -55,6 +60,29 @@ class FairDbStreamer : public TObject
     void Fill(Double_t* arr);
     void Fill(TObject* obj);
 
+
+    void Fill(void* anyObject, std::string signature);
+
+    /// vector<>
+    void Fill(std::vector<Bool_t> &vector);
+    void Fill(std::vector<Short_t> &vector);
+    void Fill(std::vector<UShort_t> &vector);
+    void Fill(std::vector<Int_t> &vector);
+    void Fill(std::vector<UInt_t> &vector);
+    void Fill(std::vector<Float_t> &vector);
+    void Fill(std::vector<Double_t> &vector);
+
+    /// vector< vector<> >
+    void Fill(std::vector< std::vector<Bool_t> > &vector);
+    void Fill(std::vector< std::vector<Short_t> > &vector);
+    void Fill(std::vector< std::vector<UShort_t> > &vector);
+    void Fill(std::vector< std::vector<Int_t> > &vector);
+    void Fill(std::vector< std::vector<UInt_t> > &vector);
+    void Fill(std::vector< std::vector<Float_t> > &vector);
+    void Fill(std::vector< std::vector<Double_t> > &vector);
+
+    /// map
+    void Fill(std::map<std::string, TObject> &map);
 
   private:
     TString fString; //!


### PR DESCRIPTION
Add possibility to stream virtually any STL classes to FairDb:

```
TString FairDb::StreamAsString(const void* anyObject, std::string signature)
```

Example:
```
root [1] std::vector<Int_t> v( {0, 1, 2} )
(std::vector<Int_t> &) { 0, 1, 2 }
root [2] FairDb::StreamAsString(&v, "std::vector<Int_t>")
(TString) "00000003000000000000000100000002"[32]
root [3] FairDbStreamer streamer
root [4] streamer.SetString("00000003000000000000000100000002")
root [5] std::vector<Int_t> vv
(std::vector<Int_t> &) {}
root [6] streamer.Fill(&vv, "std::vector<Int_t>")
root [7] vv
(std::vector<Int_t> &) { 0, 1, 2 }
```

Add predefined methods for vectors and vectors of vectors of chosen types (Bool_t, Short_t, UShort_t, Int_t, UInt_t, Float_t, Double_t).

Add a sample "dictionary" in form of a `std::map<std::string, TObject>`

TODO: move all StreamAsString methods from FairDb namespace and FairDb.h and FairDb.cxx files to the FairDbStreamer class
